### PR TITLE
Filter null values from being sent to graphite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
+
 install:
 	origami-build-tools install
+
 test:
-	next-build-tools verify;
+	mocha --reporter spec -i tests/graphite
 
 integration-test:
 	export DEBUG=graphite; node examples/app.js

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ install:
 	origami-build-tools install
 
 test:
+	next-build-tools verify --skip-layout-checks
 	mocha --reporter spec -i tests/graphite
 
 integration-test:

--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -18,7 +18,11 @@ var Graphite = function(opts) {
 Graphite.prototype.log = function(metrics) {
 	var self = this;
 
-	var data = _.map(metrics, function(value, k) {
+	// Remove nulls
+	// http://stackoverflow.com/questions/14058193/remove-empty-properties-falsy-values-from-object-with-underscore-js
+	var noNulls = _.pick(metrics, _.identity)
+
+	var data = _.map(noNulls, function(value, k) {
 		return util.format('%s%s%s %s', self.apiKey, self.prefix, k, value);
 	});
 
@@ -40,7 +44,7 @@ Graphite.prototype.log = function(metrics) {
 
 	var socket = net.createConnection(this.port, this.host, function() {
 		_.forEach(dataChunks, function(chunk) {
-				socket.write(chunk.join("\n") + "\n"); // trailing \n to ensure the last metric is registered
+			socket.write(chunk.join("\n") + "\n"); // trailing \n to ensure the last metric is registered
 		});
 		socket.end();
 	});

--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -20,7 +20,7 @@ Graphite.prototype.log = function(metrics) {
 
 	// Remove nulls
 	// http://stackoverflow.com/questions/14058193/remove-empty-properties-falsy-values-from-object-with-underscore-js
-	var noNulls = _.pick(metrics, _.identity)
+	var noNulls = _.pick(metrics, _.identity);
 
 	var data = _.map(noNulls, function(value, k) {
 		return util.format('%s%s%s %s', self.apiKey, self.prefix, k, value);

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -87,10 +87,10 @@ Metrics.prototype.count = function (metric, value) {
 
 // Allow arbitrary Histograms
 Metrics.prototype.histogram = function(metric, value){
-    if (!this.customHistograms.hasOwnProperty(metric)) {
-        this.customHistograms[metric] = new metrics.Histogram.createUniformHistogram();
-    }
-    this.customHistograms[metric].update(value);
+	if (!this.customHistograms.hasOwnProperty(metric)) {
+		this.customHistograms[metric] = new metrics.Histogram.createUniformHistogram();
+	}
+	this.customHistograms[metric].update(value);
 };
 
 Metrics.prototype.flushCustomCounters = function () {
@@ -102,15 +102,14 @@ Metrics.prototype.flushCustomCounters = function () {
 };
 
 Metrics.prototype.flushCustomHistograms = function () {
-    var obj = {};
-    _.each(this.customHistograms, function(value, key){
-        obj[key + '.min'] = value.min;
-        obj[key + '.max'] = value.max;
-        obj[key + '.mean'] = value.mean();
-        obj[key + '.count'] = value.count;
-    });
-
-    return obj;
+	var obj = {};
+	_.each(this.customHistograms, function(value, key){
+		obj[key + '.min'] = value.min;
+		obj[key + '.max'] = value.max;
+		obj[key + '.mean'] = value.mean();
+		obj[key + '.count'] = value.count;
+	});
+	return obj;
 };
 
 Metrics.prototype.setupDefaultAggregators = function () {

--- a/lib/metrics/system/process.js
+++ b/lib/metrics/system/process.js
@@ -1,11 +1,11 @@
 "use strict";
+/* jshint -W079 */
 var _ = require('lodash');
 var os = require('os');
 
 var metrics = require('metrics');
 
-
-var System = module.exports = function System() {
+var System = function() {
 
 	var versionTokens = process.version.split('.');
 
@@ -71,3 +71,5 @@ System.prototype.counts = function() {
 		'system.process.next_tick.sum': this.counters['system.process.next_tick'].sum
 	};
 };
+
+module.exports = System;

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "ft-api-client": "https://github.com/Financial-Times/ft-api-client/archive/emit-events.tar.gz",
     "lodash": "^2.4.1",
     "metrics": "^0.1.8",
+    "mocha": "^2.2.4",
     "scarlet": "^2.0.20",
     "swig": "^1.4.2"
   },
@@ -14,8 +15,8 @@
     "chai": "^1.9.1",
     "express": "^4.10.2",
     "jshint": "*",
-    "mocha": "^1.21.4",
-    "next-build-tools": "^1.20.1",
+    "mitm": "^1.1.0",
+    "next-build-tools": "^2.1.1",
     "nock": "^0.51.0",
     "npm-prepublish": "^1.2.0",
     "origami-build-tools": "^2.13.0"

--- a/tests/graphite/clientSpec.js
+++ b/tests/graphite/clientSpec.js
@@ -1,0 +1,27 @@
+
+var Graphite	= require('../../lib/graphite/client');
+var expect		= require('chai').expect;
+var Mitm		= require("mitm");	// 'man in the middle' socket proxy
+
+describe('Session Service', function() {
+
+	beforeEach(function () {
+		this.mitm = Mitm();
+	});
+
+	afterEach(function () {
+		this.mitm.disable();
+	});
+
+	it('Send metrics to Graphite', function (done) {
+		this.mitm.on("connection", function(socket) {
+			socket.on('data', function (d) { 
+				expect(d.toString('utf-8')).to.equal("k.p.a 1\nk.p.b 2\n");
+				done();
+			});
+		});
+		var g = new Graphite({ apiKey: 'k.', prefix: 'p.', noLog: false });
+		g.log({ a: 1, b: 2, c: null });
+	})
+
+})

--- a/tests/graphite/clientSpec.js
+++ b/tests/graphite/clientSpec.js
@@ -3,12 +3,12 @@
 
 var Graphite	= require('../../lib/graphite/client');
 var expect		= require('chai').expect;
-var Mitm		= require("mitm");	// 'man in the middle' socket proxy
+var mitm		= require("mitm");	// 'man in the middle' socket proxy
 
 describe('Session Service', function() {
 
 	beforeEach(function () {
-		this.mitm = Mitm();
+		this.mitm = mitm();
 	});
 
 	afterEach(function () {

--- a/tests/graphite/clientSpec.js
+++ b/tests/graphite/clientSpec.js
@@ -1,3 +1,5 @@
+'use strict';
+/*global describe, it, beforeEach, afterEach*/
 
 var Graphite	= require('../../lib/graphite/client');
 var expect		= require('chai').expect;
@@ -15,13 +17,13 @@ describe('Session Service', function() {
 
 	it('Send metrics to Graphite', function (done) {
 		this.mitm.on("connection", function(socket) {
-			socket.on('data', function (d) { 
+			socket.on('data', function (d) {
 				expect(d.toString('utf-8')).to.equal("k.p.a 1\nk.p.b 2\n");
 				done();
 			});
 		});
 		var g = new Graphite({ apiKey: 'k.', prefix: 'p.', noLog: false });
 		g.log({ a: 1, b: 2, c: null });
-	})
+	});
 
-})
+});


### PR DESCRIPTION
We've a zillion metrics in hostgraphite without any values, this stops them being sent. Also added a simple test. Need to add more at some point.

/cc @matthew-andrews @wheresrhys 