### PR TITLE
Push metrics to graphite.ft.com as well as hosted graphite

### DIFF
--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -37,13 +37,25 @@ Graphite.prototype.log = function(metrics) {
 		console.warn('Logging to Graphite is disabled by default on non-production environments. To enable is set NODE_ENV to "production".');
 		return;
 	}
-
+    
+    // update the specified hosted graphite
 	var socket = net.createConnection(this.port, this.host, function() {
 		_.forEach(dataChunks, function(chunk) {
 				socket.write(chunk.join("\n") + "\n"); // trailing \n to ensure the last metric is registered
 		});
 		socket.end();
 	});
+    
+    // now push the same data again to the FT graphite cluster:
+    // This is hardcoded, because when/if we cut over we want this to disappear.
+    // and just change the original graphite details instead
+    var ftSocket = net.createConnection(2003, "graphite.ft.com", function() {
+        _.forEach(dataChunks, function(chunk) {
+				socket.write(chunk.join("\n") + "\n"); // trailing \n to ensure the last metric is registered
+		});
+        ftSocket.end();
+    });
+
 
 	socket.on('end', function() {
 		debug('metrics client disconnected');


### PR DESCRIPTION
I've hammered a second graphite server, so we copy everything to two backends.

We'll then see if the FT graphite is working properly, and catching the correct metrics. 