### PR TITLE
Turns out you need a timestamp to make graphite work

### DIFF
--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -19,7 +19,7 @@ Graphite.prototype.log = function(metrics) {
 	var self = this;
 
 	var data = _.map(metrics, function(value, k) {
-		return util.format('%s%s%s %s', self.apiKey, self.prefix, k, value);
+		return util.format('%s%s%s %s %d', self.apiKey, self.prefix, k, value, new Date() / 1000);
 	});
 
 	// Send data in chunks of 20 metrics (maximum allowed by hosted graphite)


### PR DESCRIPTION
Hosted graphite apparently has taken away the timestamp requirement for updates. Fortunately it still understands the original format, so its a fairly simple task. 