### PR TITLE
Collect full node version number

### DIFF
--- a/lib/metrics/system/process.js
+++ b/lib/metrics/system/process.js
@@ -57,6 +57,7 @@ System.prototype.counts = function() {
 	return {
 		'system.os.cpus': os.cpus().length,
 		'system.process.uptime': process.uptime(),
+		'system.process.version.full': process.version,
 		'system.process.version.major': this.nodeVersion.major,
 		'system.process.version.minor': this.nodeVersion.minor,
 		'system.process.version.patch': this.nodeVersion.patch,


### PR DESCRIPTION
Makes it easier to look for combined minor & patch versions in graphite queries - Eg, find all servers running less than node 0.12.7 - Eg, `0.12.[0123456]`