### PR TITLE
Add pm2 instance id to graphite key if exists

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -53,6 +53,9 @@ Metrics.prototype.init = function(opts) {
 	// Derive the keys based on the platform, Eg, <platform>.<application>.<instance>.<metric>
 	var platform = (process.env.DYNO) ? 'heroku' : 'localhost';
 	var instance = (platform === 'heroku') ? process.env.DYNO.replace('.', '_') : '_';
+	if (process.env.NODE_APP_INSTANCE) {
+		instance += '_' + process.env.NODE_APP_INSTANCE;
+	}
 	if (process.env.REGION) {
 		instance += '_' + process.env.REGION;
 	}

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -54,7 +54,7 @@ Metrics.prototype.init = function(opts) {
 	var platform = (process.env.DYNO) ? 'heroku' : 'localhost';
 	var instance = (platform === 'heroku') ? process.env.DYNO.replace('.', '_') : '_';
 	if (process.env.NODE_APP_INSTANCE) {
-		instance += '_' + process.env.NODE_APP_INSTANCE;
+		instance += '_process_' + process.env.NODE_APP_INSTANCE;
 	}
 	if (process.env.REGION) {
 		instance += '_' + process.env.REGION;


### PR DESCRIPTION
As discussed in the dev huddle. We've been experimenting using [`pm2`](http://pm2.keymetrics.io/) to cluster applications within single Heroku instances. This worked successfully but reduced the application metrics by a factor of n for each additional sub process. 

This should fix the above issue by adding the pm2 process id to the graphite key for each application if it exists.

I  will report back with my findings if it works :)