### PR TITLE
Add services from preflight

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -71,5 +71,9 @@ module.exports = {
 	'session-user-data': /^https?:\/\/session-user-data.webservices.ft.com/,
 	'alphaville': /^https?:\/\/ftalphaville\.ft\.com/,
 	'tme-taxonomy-fetch': /^https:\/\/next-es-interface\.ft\.com\/tmes\//,
-	'dam': /^https:\/\/dam\.ft\.com/
+	'dam': /^https:\/\/dam\.ft\.com/,
+	'sharecode': /^https:\/\/sharecode\.ft\.com/,
+	'access': /^https:\/\/access\.ft\.com/,
+	'barrier': /^https?:\/\/barrier-app\.memb\.ft\.com/,
+	'amo': /^https:\/\/barrier-app-glb\.memb\.ft\.com\/memb\/amo\/v1\/amo-data/
 };

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -1,5 +1,4 @@
 module.exports = {
-	'amo': /^https?:\/\/barrier-app.memb\.ft\.com\/memb\/amo\/v1\/amo-data/,
 	'blogs': /^https?:\/\/blogs\.ft\.com/,
 	'capi-v1-article': /^https?:\/\/api\.ft\.com\/content\/items\/v1\/[\w\-]+/,
 	'capi-v1-page': /^https?:\/\/api\.ft\.com\/site\/v1\/pages\/[\w\-]+/,
@@ -74,6 +73,6 @@ module.exports = {
 	'dam': /^https:\/\/dam\.ft\.com/,
 	'sharecode': /^https:\/\/sharecode\.ft\.com/,
 	'access': /^https:\/\/access\.ft\.com/,
-	'barrier': /^https?:\/\/barrier-app\.memb\.ft\.com/,
-	'amo': /^https:\/\/barrier-app-glb\.memb\.ft\.com\/memb\/amo\/v1\/amo-data/
+	'amo': /^https?:\/\/barrier-app(-glb)?\.memb\.ft\.com\/memb\/amo\/v1\/amo-data/,
+	'ammit': /^https:\/\/ammit\.ft\.com/
 };


### PR DESCRIPTION
I've been moving preflight to `node-fetch` (from `request`) and the metrics libraries is missing some instrumentation