### PR TITLE
Ensure timeouts appear in the reported stats

### DIFF
--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -64,7 +64,7 @@ Fetch.prototype.instrument = function(opts) {
 								return res;
 							})
 							.catch(function(err) {
-								if (err.message.indexOf('timeout')) {
+								if (/timeout/i.test(err.message)) {
 									that.counters[prefix + '_status_timeout'].inc(1);
 								} else {
 									that.counters[prefix + '_status_failed'].inc(1);
@@ -120,6 +120,9 @@ Fetch.prototype.reporter = function() {
 
 		obj[outputPrefix + '.response.status_failed.count'] = this.counters[inputPrefix + '_status_failed'].count;
 		this.counters[inputPrefix + '_status_failed'].clear();
+
+		obj[outputPrefix + '.response.status_timeout.count'] = this.counters[inputPrefix + '_status_timeout'].count;
+		this.counters[inputPrefix + '_status_timeout'].clear();
 
 	}.bind(this));
 


### PR DESCRIPTION
Should yield, 

```
1.localhost.mattc._.flush.rate 3 1456166764.557
1.localhost.mattc._.fetch.capi-v2-article.count 29 1456166764.557
1.localhost.mattc._.fetch.capi-v2-article.response.status_timeout.count 29 1456166764.557
```