### PR TITLE
Remove metrics client socket close message

### DIFF
--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -58,10 +58,6 @@ Graphite.prototype.log = function(metrics) {
 		console.error('metrics client error', err);
 	});
 
-	socket.on('close', function(err) {
-		console.error('metrics client closed', err);
-	});
-
 	socket.on('timeout', function() {
 		console.error('metrics client timeout');
 	});


### PR DESCRIPTION
Our Heroku logs are being flooded with these messages and they aren't useful in the slightest. This is causing us to miss vital debugging/diagnostic logs in production environments. Therefore I'm killing them.