### PR TITLE
Remove node version from metrics now it is in logs instead

### DIFF
--- a/lib/metrics/system/process.js
+++ b/lib/metrics/system/process.js
@@ -8,14 +8,6 @@ var metrics = require('metrics');
 
 var System = function() {
 
-	var versionTokens = process.version.split('.');
-
-	this.nodeVersion = {
-		major: parseInt(versionTokens[0].slice(1)) || 0,
-		minor: parseInt(versionTokens[1]),
-		patch: parseInt(versionTokens[2])
-	};
-
 	this.counters = {
 		'system.process.mem_process_rss': new metrics.Counter(),
 		'system.process.mem_process_heapTotal': new metrics.Counter(),
@@ -58,10 +50,6 @@ System.prototype.counts = function() {
 	return {
 		'system.os.cpus': os.cpus().length,
 		'system.process.uptime': process.uptime(),
-		'system.process.version.full': process.version,
-		'system.process.version.major': this.nodeVersion.major,
-		'system.process.version.minor': this.nodeVersion.minor,
-		'system.process.version.patch': this.nodeVersion.patch,
 		'system.process.mem_process_rss': this.counters['system.process.mem_process_rss'].count,
 		'system.process.mem_process_heapTotal': this.counters['system.process.mem_process_heapTotal'].count,
 		'system.process.mem_process_heapUsed': this.counters['system.process.mem_process_heapUsed'].count,


### PR DESCRIPTION
@commuterjoy @keirog 
