### PR TITLE
APIs for the sign up form

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -76,4 +76,8 @@ module.exports = {
 	'brexit-stream-content': /^https?:\/\/ft-ig-brexit-stream-content\.herokuapp\.com\//,
 	'www-ft-com': /^https?:\/\/www\.ft\.com/,
 	'prod-up-read': /^https:\/\/prod-up-read\.ft\.com\//,
+	'offer-api-test': /^https:\/\/offer-api-gw-eu-west-1-test.memb.ft.com\/offers\//,
+	'subscription-api-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/subscription-ref-data\/billing-countries\//,
+	'paymentpage2-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/paymentpage2\//
+	
 };


### PR DESCRIPTION
Added the test APIs used in production for the sign up form to stop sentry errors. Must be replaced by production APIs. https://app.getsentry.com/nextftcom/ft-next-signup/issues/115589819/

cc @ifyio @commuterjoy 
