### PR TITLE
Add prod apis for signup

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -81,7 +81,7 @@ module.exports = {
 	'paymentpage2-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/paymentpage2\//,
 	'demographic-api-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/user-ref-data\/[\w\-]+\//,
 	'offer-api': /^https:\/\/offer-api-gw-eu-west-1-prod.memb.ft.com\/offers\/offerId=[\w\\]+&countryCode=[\w\-]+/,
-	'subscription-api': /^h^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/subscription-ref-data\/billing-countries\/(CAN|USA)/,
+	'subscription-api': /^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/subscription-ref-data\/billing-countries\/(CAN|USA)/,
 	'paymentpage2': /^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/paymentpage2\/[\w\-\/]+/,
 	'demographic-api': /^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/user-ref-data\/[\w\-]+\//	
 };

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -76,8 +76,12 @@ module.exports = {
 	'brexit-stream-content': /^https?:\/\/ft-ig-brexit-stream-content\.herokuapp\.com\//,
 	'www-ft-com': /^https?:\/\/www\.ft\.com/,
 	'prod-up-read': /^https:\/\/prod-up-read\.ft\.com\//,
-	'offer-api-test': /^https:\/\/offer-api-gw-eu-west-1-test.memb.ft.com\/offers\//,
+	'offer-api-test': /^https:\/\/offer-api-gw-eu-west-1-test.memb.ft.com\/offers\/offerId=[\w\\]+&countryCode=[\w\-]+/,
 	'subscription-api-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/subscription-ref-data\/billing-countries\//,
-	'paymentpage2-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/paymentpage2\//
-	
+	'paymentpage2-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/paymentpage2\//,
+	'demographic-api-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/user-ref-data\/[\w\-]+\//,
+	'offer-api': /^https:\/\/offer-api-gw-eu-west-1-prod.memb.ft.com\/offers\/offerId=[\w\\]+&countryCode=[\w\-]+/,
+	'subscription-api': /^h^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/subscription-ref-data\/billing-countries\/(CAN|USA)/,
+	'paymentpage2': /^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/paymentpage2\/[\w\-\/]+/,
+	'demographic-api': /^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/user-ref-data\/[\w\-]+\//	
 };


### PR DESCRIPTION
Also included prod and test apis for demographic fields
- [x] check prod domain
- [x] regex to include all
- [x] demographic apis

cc @ifyio, added the prod apis and regex to cover what we use. Please let me know if you spot any I've missed