### PR TITLE
Adds gift article to the metrics services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -90,6 +90,6 @@ module.exports = {
 	'anon-email-list-api': /https:\/\/anon-email-lists-eu-(prod|test)\.herokuapp\.com/,
 	'content-classification-api': /^https:\/\/ft-next-classification-api-(eu|us)\.herokuapp\.com/,
 	'speedcurve-api': /^https:\/\/api\.speedcurve\.com/,
-	'user-status-api': /^https:\/\/user-subs-status\.ft\.com/
-
+	'user-status-api': /^https:\/\/user-subs-status\.ft\.com/,
+	'gift-article-api': /^https:\/\/giftarticle\.ft\.com\/giftarticle\//
 };

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "express": "^4.13.3",
     "ft-api-client": "https://github.com/Financial-Times/ft-api-client/archive/emit-events.tar.gz",
     "jshint": "*",
-    "mitm": "^1.1.0",
+    "mitm": "1.2.0",
     "mocha": "^2.4.5",
     "next-build-tools": "^5.10.4",
     "nock": "^0.51.0",


### PR DESCRIPTION
This should stop the errors in sentry for requests like

https://giftarticle.ft.com/giftarticle/actions/gift
https://giftarticle.ft.com/giftarticle/user/credits

I believe that `next-rtcl-email-api` is the correct application based on its [README](https://github.com/financial-times/next-rtcl-email-api#get-user-credits])

@matthew-andrews @bjfletcher @i-like-robots 