### PR TITLE
More flexiblity for a non-app context

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,8 @@ The Metrics object takes the following options,
 * app (required) - A string containing the application name, Eg. router, dobi,
   engels ...
 * flushEvery (required) - A number indicating how frequently you want the
-  metrics pushed to Graphite.
+  metrics pushed to Graphite, or `false` if you want to do it manually
+  (i.e. using `.flush()`)
 
 ## Instrumentation
 

--- a/index.js
+++ b/index.js
@@ -3,3 +3,5 @@ const Metrics = require('./lib/metrics');
 module.exports = new Metrics();
 
 module.exports.services = require('./lib/metrics/services');
+
+module.exports.Metrics = Metrics;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -30,10 +30,6 @@ var Metrics = function(opts) {
 	opts = opts || {};
 
 	this.opts = {};
-	this.httpReq = new Proxies.HttpRequest();
-	this.httpRes = new Proxies.HttpResponse();
-	this.system = new Proxies.System();
-	this.fetch = new Proxies.Fetch();
 	this.aggregators = [];
 
 	// arbitrary counters
@@ -79,22 +75,25 @@ Metrics.prototype.init = function(opts) {
 		noLog: !isProduction
 	});
 
-	if (parseInt(this.opts.flushEvery) === 'NaN') {
-		throw new Error('flushEvery must be an integer');
-	}
-
 	var self = this;
 
 	if(this.opts.useDefaultAggregators !== false){
+		this.httpReq = new Proxies.HttpRequest();
+		this.httpRes = new Proxies.HttpResponse();
+		this.system = new Proxies.System();
 		this.setupDefaultAggregators();
 	}
 
 	this.setupCustomAggregators();
 
-
-	setInterval(function () {
-		self.flush();
-	}, this.opts.flushEvery);
+	if (this.opts.flushEvery !== false) {
+		if (parseInt(this.opts.flushEvery) === 'NaN') {
+			throw new Error('flushEvery must be an integer');
+		}
+		setInterval(function () {
+			self.flush();
+		}, this.opts.flushEvery);
+	}
 };
 
 // Allow arbitrary counters


### PR DESCRIPTION
 * expose the `Metrics` constructor (rather than just an instance)
 * add ability to turn off auto-flushing (with `flushEvery: false`)
 * only instantiate `Proxies` if using the default aggregators