### PR TITLE
Allow forcing of Graphite logging

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -73,7 +73,7 @@ Metrics.prototype.init = function(opts) {
 	this.graphite = new Graphite({
 		apiKey: apiKey,
 		prefix: prefix,
-		noLog: !isProduction
+		noLog: !isProduction && !opts.forceGraphiteLogging
 	});
 
 	var self = this;


### PR DESCRIPTION
So it's not just dependent on `NODE_ENV`