### PR TITLE
applying fetch metrics lazily

### DIFF
--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -20,18 +20,10 @@ Fetch.prototype.instrument = function(opts) {
 	this.serviceMatchers = services;
 	this.onUninstrumented = opts.onUninstrumented || function() {};
 	this.serviceNames = Object.keys(services);
+	this.initialisedServices = {};
 
-	this.serviceNames.forEach(function(service) {
-		this.counters['fetch_' + service + '_requests'] = new metrics.Counter();
-		this.counters['fetch_' + service + '_status_2xx_response_time'] = new metrics.Histogram.createUniformHistogram();
-		this.counters['fetch_' + service + '_status_3xx_response_time'] = new metrics.Histogram.createUniformHistogram();
-		this.counters['fetch_' + service + '_status_4xx'] = new metrics.Counter();
-		this.counters['fetch_' + service + '_status_5xx'] = new metrics.Counter();
-		this.counters['fetch_' + service + '_status_failed'] = new metrics.Counter();
-		this.counters['fetch_' + service + '_status_timeout'] = new metrics.Counter();
-	}.bind(this));
-
-	(opts.metricsInstance || require('../../index')).registerAggregator(this.reporter.bind(this));
+	(opts.metricsInstance || require('../../index'))
+		.registerAggregator(this.reporter.bind(this));
 
 	var _fetch = GLOBAL.fetch;
 
@@ -46,6 +38,7 @@ Fetch.prototype.instrument = function(opts) {
 			}
 		});
 		if (service) {
+			that.setupService(service);
 			var prefix = 'fetch_' + service;
 			that.counters[prefix + '_requests'].inc(1);
 
@@ -88,6 +81,20 @@ Fetch.prototype.instrument = function(opts) {
 		GLOBAL.fetch = _fetch;
 	};
 };
+
+Fetch.prototype.setupService = function (service) {
+	if (service in this.initialisedServices) {
+		return;
+	}
+	this.counters['fetch_' + service + '_requests'] = new metrics.Counter();
+	this.counters['fetch_' + service + '_status_2xx_response_time'] = new metrics.Histogram.createUniformHistogram();
+	this.counters['fetch_' + service + '_status_3xx_response_time'] = new metrics.Histogram.createUniformHistogram();
+	this.counters['fetch_' + service + '_status_4xx'] = new metrics.Counter();
+	this.counters['fetch_' + service + '_status_5xx'] = new metrics.Counter();
+	this.counters['fetch_' + service + '_status_failed'] = new metrics.Counter();
+	this.counters['fetch_' + service + '_status_timeout'] = new metrics.Counter();
+	this.initialisedServices[service] = true;
+}
 
 Fetch.prototype.reporter = function() {
 

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -23,9 +23,7 @@ Fetch.prototype.instrument = function(opts) {
 
 	this.serviceNames.forEach(function(service) {
 		this.counters['fetch_' + service + '_requests'] = new metrics.Counter();
-		this.counters['fetch_' + service + '_status_2xx'] = new metrics.Counter();
 		this.counters['fetch_' + service + '_status_2xx_response_time'] = new metrics.Histogram.createUniformHistogram();
-		this.counters['fetch_' + service + '_status_3xx'] = new metrics.Counter();
 		this.counters['fetch_' + service + '_status_3xx_response_time'] = new metrics.Histogram.createUniformHistogram();
 		this.counters['fetch_' + service + '_status_4xx'] = new metrics.Counter();
 		this.counters['fetch_' + service + '_status_5xx'] = new metrics.Counter();
@@ -110,10 +108,9 @@ Fetch.prototype.reporter = function() {
 		obj[outputPrefix + '.response.status_2xx.response_time.median'] = percentiles2xx[0.5];
 		obj[outputPrefix + '.response.status_2xx.response_time.95th'] = percentiles2xx[0.95];
 		obj[outputPrefix + '.response.status_2xx.response_time.99th'] = percentiles2xx[0.99];
-		histo2xx.clear();
+		obj[outputPrefix + '.response.status_2xx.count'] = histo2xx.count;
 
-		obj[outputPrefix + '.response.status_2xx.count'] = this.counters[inputPrefix + '_status_2xx'].count;
-		this.counters[inputPrefix + '_status_2xx'].clear();
+		histo2xx.clear();
 
 		const histo3xx = this.counters[inputPrefix + '_status_3xx_response_time'];
 		const percentiles3xx = histo3xx.percentiles([0.5, 0.95, 0.99]);
@@ -123,10 +120,9 @@ Fetch.prototype.reporter = function() {
 		obj[outputPrefix + '.response.status_3xx.response_time.median'] = percentiles3xx[0.5];
 		obj[outputPrefix + '.response.status_3xx.response_time.95th'] = percentiles3xx[0.95];
 		obj[outputPrefix + '.response.status_3xx.response_time.99th'] = percentiles3xx[0.99];
-		histo3xx.clear();
+		obj[outputPrefix + '.response.status_3xx.count'] = histo3xx.count;
 
-		obj[outputPrefix + '.response.status_3xx.count'] = this.counters[inputPrefix + '_status_3xx'].count;
-		this.counters[inputPrefix + '_status_3xx'].clear();
+		histo3xx.clear();
 
 		obj[outputPrefix + '.response.status_4xx.count'] = this.counters[inputPrefix + '_status_4xx'].count;
 		this.counters[inputPrefix + '_status_4xx'].clear();

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -51,27 +51,34 @@ Fetch.prototype.instrument = function(opts) {
 			var prefix = 'fetch_' + service;
 			that.counters[prefix + '_requests'].inc(1);
 
-			var start = new Date();
+			var start = Date.now();
+			let end;
 
-			return _fetch.apply(this, arguments)
-							.then(function(res) {
-								var statusType = res.status ? ('' + res.status).charAt(0) + 'xx' : '2xx';
-								var timer = that.counters[prefix + '_status_' + statusType + '_response_time'];
-								if (timer) {
-									timer.update(new Date() - start);
-								}
-								that.counters[prefix + '_status_' + statusType].inc(1);
-								return res;
-							})
-							.catch(function(err) {
-								if (/timeout/i.test(err.message)) {
-									that.counters[prefix + '_status_timeout'].inc(1);
-								} else {
-									that.counters[prefix + '_status_failed'].inc(1);
-								}
-								throw err;
-							});
+			const response = _fetch.apply(this, arguments)
 
+
+			response.then(() => {
+				end = Date.now();
+			})
+
+			// take the metrics off the microtask queue
+			setTimeout(response
+				.then(function(res) {
+					var statusType = res.status ? ('' + res.status).charAt(0) + 'xx' : '2xx';
+					var timer = that.counters[prefix + '_status_' + statusType + '_response_time'];
+					if (timer) {
+						timer.update(end - start);
+					}
+					that.counters[prefix + '_status_' + statusType].inc(1);
+				})
+				.catch(function(err) {
+					if (/timeout/i.test(err.message)) {
+						that.counters[prefix + '_status_timeout'].inc(1);
+					} else {
+						that.counters[prefix + '_status_failed'].inc(1);
+					}
+				}));
+			return response;
 		} else {
 			that.onUninstrumented.apply(this, arguments);
 			return _fetch.apply(this, arguments);

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+var metrics = require('metrics');
+var t = new metrics.Histogram();
+
+t.update(1);
+t.update(2);
+t.update(3);
+t.update(8);
+
+console.log('count', t.count)

--- a/test.js
+++ b/test.js
@@ -1,9 +1,0 @@
-var metrics = require('metrics');
-var t = new metrics.Histogram();
-
-t.update(1);
-t.update(2);
-t.update(3);
-t.update(8);
-
-console.log('count', t.count)


### PR DESCRIPTION
It's really annoying how fetch metrics aren't isolated enough due to being on the same microtask queuq. This... well I doubt it'll improve matters, but it does at least prioritise handling the response over reporting the metrics. Can't do any harm @richard-still-ft @TheoLeanse @matthew-andrews 