### PR TITLE
fix lists regex

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -13,7 +13,7 @@ module.exports = {
 	'capi-v2-brands': /^https?:\/\/api\.ft\.com\/brands\/[\w\-]+/,
 	'capi-v2-concordances': /^https?:\/\/api\.ft\.com\/concordances\?/,
 	'capi-v2-enriched-article': /^https?:\/\/api\.ft\.com\/enrichedcontent\/[\w\-]+/,
-	'capi-v2-lists': /^https?:\/\/api\.ft\.com\/lists[\/|\?][\w\-]+/,
+	'capi-v2-lists': /^https?:\/\/api\.ft\.com\/lists[\/?].*/,
 	'capi-v2-thing': /^https?:\/\/api\.ft\.com\/things\/[\w\-]+/,
 	'capi-v2-people': /^https?:\/\/api\.ft\.com\/people\/[\w\-]+/,
 	'capi-v2-organisation': /^https?:\/\/api\.ft\.com\/organisations\/[\w\-]+/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -13,7 +13,7 @@ module.exports = {
 	'capi-v2-brands': /^https?:\/\/api\.ft\.com\/brands\/[\w\-]+/,
 	'capi-v2-concordances': /^https?:\/\/api\.ft\.com\/concordances\?/,
 	'capi-v2-enriched-article': /^https?:\/\/api\.ft\.com\/enrichedcontent\/[\w\-]+/,
-	'capi-v2-lists': /^https?:\/\/api\.ft\.com\/lists[\/?].*/,
+	'capi-v2-lists': /^https?:\/\/api\.ft\.com\/lists/,
 	'capi-v2-thing': /^https?:\/\/api\.ft\.com\/things\/[\w\-]+/,
 	'capi-v2-people': /^https?:\/\/api\.ft\.com\/people\/[\w\-]+/,
 	'capi-v2-organisation': /^https?:\/\/api\.ft\.com\/organisations\/[\w\-]+/,


### PR DESCRIPTION
There's been a lot of errors for the following kind of fetch:

`https://api.ft.com/lists?curatedOpinionAnalysisFor=f814d8f7-d38e-31b8-a51f-3882805288fd`

which doesn't show up in graphite because the regex doesn't cover the equality sign (`=`) there

I've simplified the regex, to make sure it catches all fetch errors for `/lists`