### PR TITLE
Add: 2xx + 3xx fetch counters

### DIFF
--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -90,7 +90,9 @@ Fetch.prototype.setupService = function (service) {
 		return;
 	}
 	this.counters['fetch_' + service + '_requests'] = new metrics.Counter();
+	this.counters['fetch_' + service + '_status_2xx'] = new metrics.Counter();
 	this.counters['fetch_' + service + '_status_2xx_response_time'] = new metrics.Histogram.createUniformHistogram();
+	this.counters['fetch_' + service + '_status_3xx'] = new metrics.Counter();
 	this.counters['fetch_' + service + '_status_3xx_response_time'] = new metrics.Histogram.createUniformHistogram();
 	this.counters['fetch_' + service + '_status_4xx'] = new metrics.Counter();
 	this.counters['fetch_' + service + '_status_5xx'] = new metrics.Counter();
@@ -109,6 +111,9 @@ Fetch.prototype.reporter = function() {
 		obj[outputPrefix + '.count'] = this.counters[inputPrefix + '_requests'].count;
 		this.counters[inputPrefix + '_requests'].clear();
 
+		obj[outputPrefix + '.response.status_2xx.count'] = this.counters[inputPrefix + '_status_2xx'].count;
+		this.counters[inputPrefix + '_status_2xx'].clear();
+
 		const histo2xx = this.counters[inputPrefix + '_status_2xx_response_time'];
 		const percentiles2xx = histo2xx.percentiles([0.5, 0.95, 0.99]);
 		obj[outputPrefix + '.response.status_2xx.response_time.mean'] = histo2xx.mean();
@@ -117,9 +122,10 @@ Fetch.prototype.reporter = function() {
 		obj[outputPrefix + '.response.status_2xx.response_time.median'] = percentiles2xx[0.5];
 		obj[outputPrefix + '.response.status_2xx.response_time.95th'] = percentiles2xx[0.95];
 		obj[outputPrefix + '.response.status_2xx.response_time.99th'] = percentiles2xx[0.99];
-		obj[outputPrefix + '.response.status_2xx.count'] = histo2xx.count;
-
 		histo2xx.clear();
+
+		obj[outputPrefix + '.response.status_3xx.count'] = this.counters[inputPrefix + '_status_3xx'].count;
+		this.counters[inputPrefix + '_status_3xx'].clear();
 
 		const histo3xx = this.counters[inputPrefix + '_status_3xx_response_time'];
 		const percentiles3xx = histo3xx.percentiles([0.5, 0.95, 0.99]);
@@ -129,8 +135,6 @@ Fetch.prototype.reporter = function() {
 		obj[outputPrefix + '.response.status_3xx.response_time.median'] = percentiles3xx[0.5];
 		obj[outputPrefix + '.response.status_3xx.response_time.95th'] = percentiles3xx[0.95];
 		obj[outputPrefix + '.response.status_3xx.response_time.99th'] = percentiles3xx[0.99];
-		obj[outputPrefix + '.response.status_3xx.count'] = histo3xx.count;
-
 		histo3xx.clear();
 
 		obj[outputPrefix + '.response.status_4xx.count'] = this.counters[inputPrefix + '_status_4xx'].count;


### PR DESCRIPTION
cc @ironsidevsquincy 

Because `this.counters['fetch_' + service + '_status_2xx']` and `this.counters['fetch_' + service + '_status_3xx']` did not exist, [this line](https://github.com/Financial-Times/next-metrics/blob/master/lib/metrics/fetch.js#L64) was throwing an error (`.inc()` cannot be called on undefined) and so every successful 2xx or 3xx response would _also_ increment the number of `that.counters[prefix + '_status_timeout']` or `that.counters[prefix + '_status_failed']`.

As an example, the fetches from `next-api` to `aws-elastic-v3-search` had identical graphs for both `status_2xx` and `status_failed` counts.

#### status_2xx
![status_2xx](https://cloud.githubusercontent.com/assets/10484515/19723974/ade89aa8-9b75-11e6-962b-b78e890d0362.png)

#### status_failed
![status_failed](https://cloud.githubusercontent.com/assets/10484515/19723976/b215afda-9b75-11e6-8a64-e41b545b3b1d.png)
