### PR TITLE
Updates flags regex to allow for protocol-less urls

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -8,7 +8,7 @@ module.exports = {
 	'aws-elastic-v3-search': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elastic\.ft\.com)\/v3_api_v2\/(item\/)?_search/,
 	'aws-elastic-v3-item': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elastic\.ft\.com)\/v3_api_v2\/item/,
 	'ft-next-api-user-prefs-v002': /^https?:\/\/ft-next-api-user-prefs-v002\.herokuapp\.com/,
-	'api-feature-flags': /^https?:\/\/(?:ft-next-feature-flags-prod(-us)?\..*\.amazonaws\.com|next-flags\.ft\.com)/,
+	'api-feature-flags': /^(https?:)?\/\/(?:ft-next-feature-flags-prod(-us)?\..*\.amazonaws\.com|next-flags\.ft\.com)/,
 	'capi-v2-article': /^https?:\/\/api\.ft\.com\/content\/[\w\-]+/,
 	'capi-v2-brands': /^https?:\/\/api\.ft\.com\/brands\/[\w\-]+/,
 	'capi-v2-concordances': /^https?:\/\/api\.ft\.com\/concordances\?/,


### PR DESCRIPTION
Because of this
https://github.com/Financial-Times/next-flags-ui/blob/d0b712d1ec51e1b6051fbd3dc4e6441f16d2ca6d/server/controllers/flags.js#L26

and just because why not?