### PR TITLE
Allow setting API keys through the options object

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ The Metrics object takes the following options,
 * flushEvery (required) - A number indicating how frequently you want the
   metrics pushed to Graphite, or `false` if you want to do it manually
   (i.e. using `.flush()`)
+* hostedApiKey (optional) - The API key for hostedgraphite. This defaults to the environment variable `HOSTEDGRAPHITE_APIKEY`, but this configuration overrides that. Set to `false` to disable hostedgraphite.
+* ftApiKey (optional) - The API key for the FT's internal Graphite. This defaults to the environment variable `FT_GRAPHITE_APIKEY`, but this configuration overrides that. Set to `false` to disable internal Graphite.
 
 ## Instrumentation
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -21,12 +21,6 @@ var _ = require('lodash');
 var Graphite = require('../lib/graphite/client');
 var metrics = require('metrics');
 
-var hostedApiKey = process.env.HOSTEDGRAPHITE_APIKEY;
-var ftApiKey = process.env.FT_GRAPHITE_APIKEY || process.env.HOSTEDGRAPHITE_APIKEY;
-
-if (!hostedApiKey && process.env.NODE_ENV === 'production') throw "No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on your localhost.";
-if (!ftApiKey && process.env.NODE_ENV === 'production') throw "No FT_GRAPHITE_APIKEY is set. Please set a false one if you are on your localhost.";
-
 var Metrics = function(opts) {
 
 	opts = opts || {};
@@ -47,6 +41,20 @@ Metrics.prototype.init = function(opts) {
 	}
 
 	this.opts = opts;
+
+	// Get the API keys
+	if (!opts.hostedApiKey && opts.hostedApiKey !== false) {
+		opts.hostedApiKey = opts.hostedApiKey || process.env.HOSTEDGRAPHITE_APIKEY;
+		if (!opts.hostedApiKey && process.env.NODE_ENV === 'production') {
+			throw new Error('No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on localhost.');
+		}
+	}
+	if (!opts.ftApiKey && opts.ftApiKey !== false) {
+		opts.ftApiKey = opts.ftApiKey || process.env.FT_GRAPHITE_APIKEY || opts.hostedApiKey;
+		if (!opts.ftApiKey && process.env.NODE_ENV === 'production') {
+			throw new Error('No FT_GRAPHITE_APIKEY is set. Please set a false one if you are on localhost.');
+		}
+	}
 
 	// Derive the keys based on the platform, Eg, <platform>.<application>.<instance>.<metric>
 	var platform = this.opts.platform || ((process.env.DYNO) ? 'heroku' : 'localhost');
@@ -75,17 +83,17 @@ Metrics.prototype.init = function(opts) {
 	// If API keys have been explicitly set to `false`, we don't
 	// send metrics
 	var destinations = [];
-	if (hostedApiKey && hostedApiKey !== 'false') {
+	if (opts.hostedApiKey && opts.hostedApiKey !== 'false') {
 		destinations.push({
 			host: 'carbon.hostedgraphite.com',
-			key: hostedApiKey,
+			key: opts.hostedApiKey,
 			port: 2003
 		});
 	}
-	if (ftApiKey && ftApiKey !== 'false') {
+	if (opts.ftApiKey && opts.ftApiKey !== 'false') {
 		destinations.push({
 			host: 'graphite.ft.com',
-			key: ftApiKey,
+			key: opts.ftApiKey,
 			port: 2003
 		});
 	}

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -46,13 +46,13 @@ Metrics.prototype.init = function(opts) {
 	if (!opts.hostedApiKey && opts.hostedApiKey !== false) {
 		opts.hostedApiKey = opts.hostedApiKey || process.env.HOSTEDGRAPHITE_APIKEY;
 		if (!opts.hostedApiKey && process.env.NODE_ENV === 'production') {
-			throw new Error('No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on localhost.');
+			throw new Error('No HOSTEDGRAPHITE_APIKEY is set. Please explicitly set to false if you don\'t wish to use Hosted Graphite.');
 		}
 	}
 	if (!opts.ftApiKey && opts.ftApiKey !== false) {
 		opts.ftApiKey = opts.ftApiKey || process.env.FT_GRAPHITE_APIKEY || opts.hostedApiKey;
 		if (!opts.ftApiKey && process.env.NODE_ENV === 'production') {
-			throw new Error('No FT_GRAPHITE_APIKEY is set. Please set a false one if you are on localhost.');
+			throw new Error('No FT_GRAPHITE_APIKEY is set. Please explicitly set to false if you don\'t wish to use Internal Graphite.');
 		}
 	}
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -43,14 +43,21 @@ Metrics.prototype.init = function(opts) {
 	this.opts = opts;
 
 	// Get the API keys
+	var envKeys = {
+		HOSTEDGRAPHITE_APIKEY: (process.env.HOSTEDGRAPHITE_APIKEY === 'false' ? false : process.env.HOSTEDGRAPHITE_APIKEY),
+		FT_GRAPHITE_APIKEY: (process.env.FT_GRAPHITE_APIKEY === 'false' ? false : process.env.FT_GRAPHITE_APIKEY)
+	};
 	if (!opts.hostedApiKey && opts.hostedApiKey !== false) {
-		opts.hostedApiKey = opts.hostedApiKey || process.env.HOSTEDGRAPHITE_APIKEY;
+		opts.hostedApiKey = opts.hostedApiKey || envKeys.HOSTEDGRAPHITE_APIKEY;
 		if (!opts.hostedApiKey && process.env.NODE_ENV === 'production') {
 			throw new Error('No HOSTEDGRAPHITE_APIKEY is set. Please explicitly set to false if you don\'t wish to use Hosted Graphite.');
 		}
 	}
 	if (!opts.ftApiKey && opts.ftApiKey !== false) {
-		opts.ftApiKey = opts.ftApiKey || process.env.FT_GRAPHITE_APIKEY || opts.hostedApiKey;
+		opts.ftApiKey = opts.ftApiKey || envKeys.FT_GRAPHITE_APIKEY;
+		if (!opts.ftApiKey && opts.ftApiKey !== false) {
+			opts.ftApiKey = opts.hostedApiKey;
+		}
 		if (!opts.ftApiKey && process.env.NODE_ENV === 'production') {
 			throw new Error('No FT_GRAPHITE_APIKEY is set. Please explicitly set to false if you don\'t wish to use Internal Graphite.');
 		}
@@ -83,14 +90,14 @@ Metrics.prototype.init = function(opts) {
 	// If API keys have been explicitly set to `false`, we don't
 	// send metrics
 	var destinations = [];
-	if (opts.hostedApiKey && opts.hostedApiKey !== 'false') {
+	if (opts.hostedApiKey) {
 		destinations.push({
 			host: 'carbon.hostedgraphite.com',
 			key: opts.hostedApiKey,
 			port: 2003
 		});
 	}
-	if (opts.ftApiKey && opts.ftApiKey !== 'false') {
+	if (opts.ftApiKey) {
 		destinations.push({
 			host: 'graphite.ft.com',
 			key: opts.ftApiKey,

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -189,7 +189,7 @@ describe('lib/metrics', () => {
 			it('throws an error', () => {
 				assert.throws(() => {
 					instance.init(options);
-				}, 'No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on localhost.');
+				}, 'No HOSTEDGRAPHITE_APIKEY is set. Please explicitly set to false if you don\'t wish to use Hosted Graphite.');
 			});
 
 		});

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -1,11 +1,21 @@
 'use strict';
 
 const assert = require('chai').assert;
+const mockery = require('mockery');
+const sinon = require('sinon');
 
 describe('lib/metrics', () => {
+	let Graphite;
+	let metrics;
 	let Metrics;
 
 	beforeEach(() => {
+		metrics = require('../mock/metrics.mock');
+		mockery.registerMock('metrics', metrics);
+
+		Graphite = require('../mock/graphite.mock');
+		mockery.registerMock('../lib/graphite/client', Graphite);
+
 		Metrics = require('../../../lib/metrics');
 	});
 
@@ -13,6 +23,177 @@ describe('lib/metrics', () => {
 		assert.isFunction(Metrics);
 	});
 
-	it('has tests');
+	it('has a full suite of tests');
+
+	describe('key configuration', () => {
+		let instance;
+		let options;
+		let originalEnv;
+
+		beforeEach(() => {
+			options = {
+				app: 'test',
+				useDefaultAggregators: false
+			};
+			originalEnv = {
+				HOSTEDGRAPHITE_APIKEY: process.env.HOSTEDGRAPHITE_APIKEY,
+				FT_GRAPHITE_APIKEY: process.env.FT_GRAPHITE_APIKEY,
+				NODE_ENV: process.env.NODE_ENV
+			};
+			delete process.env.HOSTEDGRAPHITE_APIKEY;
+			delete process.env.FT_GRAPHITE_APIKEY;
+			process.env.NODE_ENV = 'test';
+			instance = new Metrics();
+		});
+
+		afterEach(() => {
+			process.env.HOSTEDGRAPHITE_APIKEY = originalEnv.HOSTEDGRAPHITE_APIKEY;
+			process.env.FT_GRAPHITE_APIKEY = originalEnv.FT_GRAPHITE_APIKEY;
+			process.env.NODE_ENV = originalEnv.NODE_ENV;
+		});
+
+		describe('when both environment variables are set', () => {
+
+			beforeEach(() => {
+				process.env.HOSTEDGRAPHITE_APIKEY = 'mock-hosted-key-env';
+				process.env.FT_GRAPHITE_APIKEY = 'mock-internal-key-env';
+				instance.init(options);
+			});
+
+			it('creates a Graphite client with the expected destinations', () => {
+				assert.calledOnce(Graphite);
+				assert.isObject(Graphite.firstCall.args[0]);
+				assert.deepEqual(Graphite.firstCall.args[0].destinations, [
+					{
+						host: 'carbon.hostedgraphite.com',
+						key: 'mock-hosted-key-env',
+						port: 2003
+					},
+					{
+						host: 'graphite.ft.com',
+						key: 'mock-internal-key-env',
+						port: 2003
+					}
+				]);
+			});
+
+		});
+
+		describe('when only the HOSTEDGRAPHITE_APIKEY environment variable is set', () => {
+
+			beforeEach(() => {
+				process.env.HOSTEDGRAPHITE_APIKEY = 'mock-hosted-key-env';
+				instance.init(options);
+			});
+
+			it('creates a Graphite client with the expected destinations', () => {
+				assert.calledOnce(Graphite);
+				assert.isObject(Graphite.firstCall.args[0]);
+				assert.deepEqual(Graphite.firstCall.args[0].destinations, [
+					{
+						host: 'carbon.hostedgraphite.com',
+						key: 'mock-hosted-key-env',
+						port: 2003
+					},
+					{
+						host: 'graphite.ft.com',
+						key: 'mock-hosted-key-env',
+						port: 2003
+					}
+				]);
+			});
+
+		});
+
+		describe('when the HOSTEDGRAPHITE_APIKEY environment variable is set and FT_GRAPHITE_APIKEY is set to "false"', () => {
+
+			beforeEach(() => {
+				process.env.HOSTEDGRAPHITE_APIKEY = 'mock-hosted-key-env';
+				process.env.FT_GRAPHITE_APIKEY = 'false';
+				instance.init(options);
+			});
+
+			it('creates a Graphite client with the expected destinations', () => {
+				assert.calledOnce(Graphite);
+				assert.isObject(Graphite.firstCall.args[0]);
+				assert.deepEqual(Graphite.firstCall.args[0].destinations, [
+					{
+						host: 'carbon.hostedgraphite.com',
+						key: 'mock-hosted-key-env',
+						port: 2003
+					}
+				]);
+			});
+
+		});
+
+		describe('when both options are set', () => {
+
+			beforeEach(() => {
+				process.env.HOSTEDGRAPHITE_APIKEY = 'mock-hosted-key-env';
+				process.env.FT_GRAPHITE_APIKEY = 'mock-internal-key-env';
+				options.hostedApiKey = 'mock-hosted-key-opt';
+				options.ftApiKey = 'mock-internal-key-opt';
+				instance.init(options);
+			});
+
+			it('creates a Graphite client with the expected destinations', () => {
+				assert.calledOnce(Graphite);
+				assert.isObject(Graphite.firstCall.args[0]);
+				assert.deepEqual(Graphite.firstCall.args[0].destinations, [
+					{
+						host: 'carbon.hostedgraphite.com',
+						key: 'mock-hosted-key-opt',
+						port: 2003
+					},
+					{
+						host: 'graphite.ft.com',
+						key: 'mock-internal-key-opt',
+						port: 2003
+					}
+				]);
+			});
+
+		});
+
+		describe('when both options are set but ftApiKey is set to `false`', () => {
+
+			beforeEach(() => {
+				process.env.HOSTEDGRAPHITE_APIKEY = 'mock-hosted-key-env';
+				process.env.FT_GRAPHITE_APIKEY = 'mock-internal-key-env';
+				options.hostedApiKey = 'mock-hosted-key-opt';
+				options.ftApiKey = false;
+				instance.init(options);
+			});
+
+			it('creates a Graphite client with the expected destinations', () => {
+				assert.calledOnce(Graphite);
+				assert.isObject(Graphite.firstCall.args[0]);
+				assert.deepEqual(Graphite.firstCall.args[0].destinations, [
+					{
+						host: 'carbon.hostedgraphite.com',
+						key: 'mock-hosted-key-opt',
+						port: 2003
+					}
+				]);
+			});
+
+		});
+
+		describe('when nothing is set and NODE_ENV is "production"', () => {
+
+			beforeEach(() => {
+				process.env.NODE_ENV = 'production';
+			});
+
+			it('throws an error', () => {
+				assert.throws(() => {
+					instance.init(options);
+				}, 'No HOSTEDGRAPHITE_APIKEY is set. Please set a false one if you are on localhost.');
+			});
+
+		});
+
+	});
 
 });

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -2,7 +2,6 @@
 
 const assert = require('chai').assert;
 const mockery = require('mockery');
-const sinon = require('sinon');
 
 describe('lib/metrics', () => {
 	let Graphite;

--- a/test/unit/mock/graphite.mock.js
+++ b/test/unit/mock/graphite.mock.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const sinon = require('sinon');
+
+const Graphite = module.exports = sinon.stub();
+
+Graphite.mockInstance = {
+	log: sinon.stub()
+};
+
+Graphite.returns(Graphite.mockInstance);


### PR DESCRIPTION
This mostly means that apps no longer need to specify an
FT_GRAPHITE_APIKEY environment variable just to turn it off. We do this
in Origami Services currently.

Also it feels wrong that every instance of Metrics has to share the same
API keys.