### PR TITLE
Do not warn about logging to Graphite being disabled in non-production environment

### DIFF
--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -35,8 +35,6 @@ Graphite.prototype.log = function (metrics) {
 	// NODE_ENV environment flag.
 
 	if (this.noLog) {
-		logger.warn(`Logging to Graphite is disabled by default on non-production environments.
-To enable it set NODE_ENV to "production".`);
 		return;
 	}
 


### PR DESCRIPTION
I'm proposing to get rid of these warnings:

![image](https://user-images.githubusercontent.com/3853889/38743205-66f693be-3f36-11e8-8d7f-694b104d3eb0.png)

I'd argue that we don't need hundreds of these warning cluttering the output of all next apps. I find that they make development and debugging a bit more tedious than necessary.

Does anybody agree with me?