### PR TITLE
Don't send full node version to metrics

### DIFF
--- a/lib/metrics/system/process.js
+++ b/lib/metrics/system/process.js
@@ -59,7 +59,6 @@ System.prototype.counts = function () {
 	return {
 		'system.os.cpus': os.cpus().length,
 		'system.process.uptime': process.uptime(),
-		'system.process.version.full': process.version,
 		'system.process.version.major': this.nodeVersion.major,
 		'system.process.version.minor': this.nodeVersion.minor,
 		'system.process.version.patch': this.nodeVersion.patch,

--- a/test/unit/lib/metrics/system/process.spec.js
+++ b/test/unit/lib/metrics/system/process.spec.js
@@ -138,10 +138,6 @@ describe('lib/metrics/system/process', () => {
 					assert.strictEqual(returnValue['system.process.uptime'], 12345);
 				});
 
-				it('has a `system.process.version.full` property set to `process.version`', () => {
-					assert.strictEqual(returnValue['system.process.version.full'], process.version);
-				});
-
 				it('has a `system.process.version.major` property set to the major Node.js version', () => {
 					assert.strictEqual(returnValue['system.process.version.major'], instance.nodeVersion.major);
 				});


### PR DESCRIPTION
The full version is something like `v8.11.0`, which doesn't make sense as a metric count.