### PR TITLE
Upgrade lodash to latest version

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@financial-times/n-logger": "^5.5.6",
     "debug": "^1.0.4",
-    "lodash": "^2.4.1",
+    "lodash": "^4.17.10",
     "metrics": "^0.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
This was causing another app to fail when i was trying to use something that depended on something that depended on this.

Also, seeing as we only use `pick`, `map`, `groupBy`, `mapValues` and `forEach` (the last of which appears to be being used on an array) i question whether we need all of lodash here or not.

(we can use much simpler and smaller alternative such as a few `just` packages or `pingu`)

 🐿 v2.10.0