### PR TITLE
Unblock v2.x.x releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See the [example app](./examples/app.js) for more information.
 ### Configuration
 
 To use this libary you need to set an environment variable named
-`FT_GRAPHITE_APIKEY`. This library will automatically pick up that
+`FT_GRAPHITE_APIKEY` or `HOSTEDGRAPHITE_APIKEY`. This library will automatically pick up that
 environment variable and use it to authenticate with FT's internal
 Graphite server when sending metrics.
 
@@ -53,7 +53,7 @@ This library will only send metrics when it is running in production
 (`NODE_ENV=production`).
 
 If you don't want to send metrics from an app in production, you must explicitly
-set the value of `FT_GRAPHITE_APIKEY` to `false`.
+set the value of `FT_GRAPHITE_APIKEY` or `HOSTEDGRAPHITE_APIKEY` to `false`.
 
 _Note: Don't use the production FT Graphite API key on your `localhost` as you will fill up FT's internal Graphite server with your local data!_
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,18 @@ The `Metrics.init` method takes the following options:
 * `instance` (optional, default: dynamically generated string) - `string|boolean` - Specify a custom instance name in the [Graphite key](#metrics), or set to `false` to omit it
 * `useDefaultAggregators` (optional, default: true) - `boolean` - Set to `false` if you want to disable default aggregators
 
+### Checking configuration
+
+Configuration errors are logged using [`n-logger`](https://github.com/Financial-Times/n-logger).
+It depends on your app configuration, but in most cases, for an app running
+in production the logs will be sent to Splunk.
+
+The `Metrics` class exposes a `hasValidConfiguration` boolean property which
+you can use to determine if an instance of `Metrics` is correctly configured
+to talk to FT Graphite. You might find it useful to check this property
+after calling the `Metrics.init` method. See '[Custom use cases](#custom-use-cases)'
+for more information on the `Metrics` class.
+
 ### Custom use cases
 
 Typically you'll only want a single instance of the [`Metrics`](https://github.com/Financial-Times/next-metrics/blob/master/lib/metrics.js)

--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -9,7 +9,9 @@ const Graphite = function (opts) {
 	this.noLog = opts.noLog;
 
 	if (!this.prefix) {
-		throw new Error('next-metrics: No opts.prefix specified');
+		logger.error({ event: 'NEXT_METRICS_NO_PREFIX_SPECIFIED', message: 'No opts.prefix specified' });
+		this.noLog = true;
+		return;
 	}
 };
 
@@ -44,15 +46,15 @@ Graphite.prototype.log = function (metrics) {
 	});
 
 	socket.on('end', function () {
-		logger.debug('next-metrics: metrics client disconnected');
+		logger.debug({ event: 'METRICS_CLIENT_DISCONNECTED' });
 	});
 
 	socket.on('error', function (err) {
-		logger.error('next-metrics: metrics client error', err);
+		logger.error({ event: 'METRICS_CLIENT_ERROR', error: err.toString() });
 	});
 
 	socket.on('timeout', function () {
-		logger.error('next-metrics: metrics client timeout');
+		logger.error({ event: 'METRICS_CLIENT_TIMEOUT' });
 	});
 
 };

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -33,15 +33,18 @@ const Metrics = function () {
 	// arbitrary counters
 	this.customCounters = {};
 	this.customHistograms = {};
+	this.hasValidConfiguration = false;
 };
 
 Metrics.prototype.init = function (opts) {
 	if (this.graphite) {
-		logger.warn('next-metrics: Already configured, not re-initialising');
+		logger.warn({ event: 'NEXT_METRICS_ALREADY_CONFIGURED', message: 'Already configured, not re-initialising' });
 		return;
 	}
 
 	this.opts = opts;
+
+	let hasValidConfiguration = true;
 
 	// Note: Support for the legacy HOSTEDGRAPHITE_APIKEY environment variable
 	// will be removed in a future release
@@ -51,13 +54,15 @@ Metrics.prototype.init = function (opts) {
 	const noValidGraphiteApiKey = (!FT_GRAPHITE_APIKEY);
 
 	if (!this.opts.app) {
-		throw new Error('next-metrics: You need to specify an application name in the configuration options. See the next-metrics README: https://github.com/Financial-Times/next-metrics');
+		hasValidConfiguration = false;
+		logger.error({ event: 'NEXT_METRICS_INVALID_APP_NAME', message: 'You need to specify an application name in the configuration options. See the next-metrics README: https://github.com/Financial-Times/next-metrics' });
 	}
 	if (!disableGraphiteMetrics && isProduction && noValidGraphiteApiKey) {
-		throw new Error('next-metrics: The environment variable FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite');
+		hasValidConfiguration = false;
+		logger.error({ event: 'NEXT_METRICS_INVALID_PRODUCTION_CONFIG', message: 'The environment variable FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite' });
 	}
 	if (disableGraphiteMetrics) {
-		logger.info('next-metrics: FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY is set to \'false\', metrics will not be sent to FT\'s internal Graphite');
+		logger.info({ event: 'NEXT_METRICS_DISABLED', message: 'FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY is set to \'false\', metrics will not be sent to FT\'s internal Graphite' });
 	}
 
 	// Derive the keys based on the platform e.g. <platform>.<application>.<instance>.<metric>
@@ -86,7 +91,7 @@ Metrics.prototype.init = function (opts) {
 	if (!isProduction && !opts.forceGraphiteLogging) {
 		noLog = true;
 	}
-	if (disableGraphiteMetrics) {
+	if (disableGraphiteMetrics || !hasValidConfiguration) {
 		noLog = true;
 	}
 
@@ -102,7 +107,7 @@ Metrics.prototype.init = function (opts) {
 		noLog,
 	});
 
-	let self = this;
+	this.hasValidConfiguration = hasValidConfiguration;
 
 	if(this.opts.useDefaultAggregators !== false){
 		this.httpReq = new Proxies.HttpRequest();
@@ -113,9 +118,12 @@ Metrics.prototype.init = function (opts) {
 
 	this.setupCustomAggregators();
 
+	let self = this;
+
 	if (this.opts.flushEvery !== false) {
 		if (parseInt(this.opts.flushEvery) === 'NaN') {
-			throw new Error('next-metrics: flushEvery must be an integer');
+			logger.error({ event: 'NEXT_METRICS_INVALID_FLUSH_EVERY_OPTION_VALUE', message: 'opts.flushEvery must be an integer' });
+			return;
 		}
 		setInterval(function () {
 			self.flush();

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -43,7 +43,9 @@ Metrics.prototype.init = function (opts) {
 
 	this.opts = opts;
 
-	let FT_GRAPHITE_APIKEY = process.env.FT_GRAPHITE_APIKEY;
+	// Note: Support for the legacy HOSTEDGRAPHITE_APIKEY environment variable
+	// will be removed in a future release
+	let FT_GRAPHITE_APIKEY = process.env.FT_GRAPHITE_APIKEY || process.env.HOSTEDGRAPHITE_APIKEY;
 	const isProduction = (process.env.NODE_ENV === 'production');
 	const disableGraphiteMetrics = (FT_GRAPHITE_APIKEY && FT_GRAPHITE_APIKEY === 'false');
 	const noValidGraphiteApiKey = (!FT_GRAPHITE_APIKEY);
@@ -52,10 +54,10 @@ Metrics.prototype.init = function (opts) {
 		throw new Error('next-metrics: You need to specify an application name in the configuration options. See the next-metrics README: https://github.com/Financial-Times/next-metrics');
 	}
 	if (!disableGraphiteMetrics && isProduction && noValidGraphiteApiKey) {
-		throw new Error('next-metrics: The environment variable FT_GRAPHITE_APIKEY must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite');
+		throw new Error('next-metrics: The environment variable FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite');
 	}
 	if (disableGraphiteMetrics) {
-		logger.info('next-metrics: FT_GRAPHITE_APIKEY is set to \'false\', metrics will not be sent to FT\'s internal Graphite');
+		logger.info('next-metrics: FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY is set to \'false\', metrics will not be sent to FT\'s internal Graphite');
 	}
 
 	// Derive the keys based on the platform e.g. <platform>.<application>.<instance>.<metric>

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -35,7 +35,7 @@ module.exports = class {
 			throw new Error('next-metrics: You need to `require(\'isomorphic-fetch\');` before instrumenting it');
 		}
 		if (global.fetch._instrumented) {
-			return logger.warn('next-metrics: You can only instrument fetch once. Remember, if you’re using next-express metrics for most fetch calls are setup automatically');
+			return logger.warn({ event: 'NEXT_METRICS_FETCH_ALREADY_INSTRUMENTED', message: 'You can only instrument fetch once. Remember, if you\'re using next-express metrics, most fetch calls are setup automatically' });
 		}
 
 		// FIXME: dynamic require so it doesn't get in a circular loop

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -110,12 +110,13 @@ describe('lib/metrics', () => {
 			beforeEach(() => {
 				process.env.NODE_ENV = 'production';
 				process.env.FT_GRAPHITE_APIKEY = '';
+				instance.init(options);
 			});
 
-			it('an error should be thrown', () => {
-				assert.throws(() => {
-					instance.init(options);
-				}, 'next-metrics: The environment variable FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite');
+			it('an error message with the event NEXT_METRICS_INVALID_PRODUCTION_CONFIG should be logged', () => {
+				assert.calledOnce(nLogger.default.error);
+				assert.isObject(nLogger.default.error.firstCall.args[0]);
+				assert.equal(nLogger.default.error.firstCall.args[0].event, 'NEXT_METRICS_INVALID_PRODUCTION_CONFIG');
 			});
 
 		});
@@ -124,12 +125,13 @@ describe('lib/metrics', () => {
 
 			beforeEach(() => {
 				process.env.NODE_ENV = 'production';
+				instance.init(options);
 			});
 
-			it('an error should be thrown', () => {
-				assert.throws(() => {
-					instance.init(options);
-				}, 'next-metrics: The environment variable FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite');
+			it('an error message with the event NEXT_METRICS_INVALID_PRODUCTION_CONFIG should be logged', () => {
+				assert.calledOnce(nLogger.default.error);
+				assert.isObject(nLogger.default.error.firstCall.args[0]);
+				assert.equal(nLogger.default.error.firstCall.args[0].event, 'NEXT_METRICS_INVALID_PRODUCTION_CONFIG');
 			});
 
 		});
@@ -151,9 +153,10 @@ describe('lib/metrics', () => {
 			it('metric logging should be disabled for the Graphite client (opts.noLog)', () => {
 				assert.isTrue(Graphite.firstCall.args[0].noLog);
 			});
-			it('an info message should be logged that explains that metric logging is disabled', () => {
+			it('an info message with the event NEXT_METRICS_DISABLED should be logged', () => {
 				assert.calledOnce(nLogger.default.info);
-				assert.equal(nLogger.default.info.firstCall.args[0], 'next-metrics: FT_GRAPHITE_APIKEY or HOSTEDGRAPHITE_APIKEY is set to \'false\', metrics will not be sent to FT\'s internal Graphite');
+				assert.isObject(nLogger.default.info.firstCall.args[0]);
+				assert.equal(nLogger.default.info.firstCall.args[0].event, 'NEXT_METRICS_DISABLED');
 			});
 
 		});


### PR DESCRIPTION
- Temporarily reinstate HOSTEDGRAPHITE_APIKEY env variable support
- Change behaviour of next-metrics so bad config won't crash an app (see commit message for more detail)