### PR TITLE
Remove legacy FT Graphite support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,14 +24,14 @@ verify-coverage:
 # Test tasks
 # ----------
 
-test: verify test-unit-coverage verify-coverage
+test: verify unit-test-coverage verify-coverage
 	@$(DONE)
 
-test-unit:
+unit-test:
 	@NODE_ENV=test mocha test/unit --recursive
 	@$(DONE)
 
-test-unit-coverage:
+unit-test-coverage:
 	@NODE_ENV=test nyc --reporter=text --reporter=html node_modules/.bin/_mocha test/unit --recursive
 	@$(DONE)
 

--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ test: verify unit-test-coverage verify-coverage
 	@$(DONE)
 
 unit-test:
-	@NODE_ENV=test mocha test/unit --recursive
+	@NODE_ENV=test mocha test/unit --recursive || echo "NOTE: Unit tests must be run under Node v6.x due to mitm dev dependency (TODO: Fix this - see README for more details)"
 	@$(DONE)
 
 unit-test-coverage:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ _Note: Don't use the production FT Graphite API key on your `localhost` as you w
 
 The `Metrics.init` method takes the following options:
 
-* `app` (required) - `string` - Application name e.g. router
+* [DEPRECATED] `app` (required) - `string` - Application name e.g. router
 * `flushEvery` (required) - `integer|boolean` - Specify how frequently you want metrics pushed to Graphite, or `false` if you want to do it manually with `.flush()`
 * `forceGraphiteLogging` (optional) - `boolean` - Set to `true` if you want to log metrics to Graphite from code running in a non-production environment (when `NODE_ENV != production`)
 * `platform` (optional, default: heroku) - `string` - Specify a custom platform name in the [Graphite key](#metrics)
@@ -156,14 +156,14 @@ argument specifies what type of object it is.
 Data is logged in the form of Graphite keys (dots denote hierarchy):
 
 ```
-<platform>.<application>.<instance>.<metric>   <value>
+<team>.<platform>.<application>.<instance>.<metric>   <value>
 ```
 
 e.g.
 
 ```
-heroku.ads-api.web_1_process_cluster_worker_1_EU.express.concept_GET.res.status.200.time.sum 325.6
-heroku.ads-api.web_1_process_cluster_worker_1_EU.system.process.mem_process_heapUsed 16213144
+next.heroku.ads-api.web_1_process_cluster_worker_1_EU.express.concept_GET.res.status.200.time.sum 325.6
+next.heroku.ads-api.web_1_process_cluster_worker_1_EU.system.process.mem_process_heapUsed 16213144
 ```
 
 You can view data in [Graphite](http://graphite.ft.com/), or in a more user-friendly UI through [Grafana](http://grafana.ft.com).

--- a/README.md
+++ b/README.md
@@ -115,8 +115,7 @@ const { GraphiteClient } = require('next-metrics');
 const graphite = new GraphiteClient({
     destination: {
         port: 2003,
-        host: 'some.host.com',
-        key: 'some-app-specific-id'
+        host: 'some.host.com'
     },
     prefix: 'some_prefix.',
     noLog: false,

--- a/README.md
+++ b/README.md
@@ -151,6 +151,14 @@ metrics.instrument(res, { as: 'express.http.res' });
 The first argument is the object you want to instrument, and the second
 argument specifies what type of object it is.
 
+## Note about unit tests and Node v6.x
+
+The unit tests must be run under Node v6.x.x due to the dev dependency of
+`mitm@1.2.0` which doesn't work on newer versions of Node. The unit tests that
+depend on `mitm` need rewriting if we want to use a newer version of `mitm`.
+
+Related `next-metrics` issue: [mitm pinned to 1.2.0 due to failing tests (#111)](https://github.com/Financial-Times/next-metrics/issues/111)
+
 ## Metrics
 
 Data is logged in the form of Graphite keys (dots denote hierarchy):

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ _Note: Don't use the production FT Graphite API key on your `localhost` as you w
 
 The `Metrics.init` method takes the following options:
 
-* [DEPRECATED] `app` (required) - `string` - Application name e.g. router
 * `flushEvery` (required) - `integer|boolean` - Specify how frequently you want metrics pushed to Graphite, or `false` if you want to do it manually with `.flush()`
 * `forceGraphiteLogging` (optional) - `boolean` - Set to `true` if you want to log metrics to Graphite from code running in a non-production environment (when `NODE_ENV != production`)
-* `platform` (optional, default: heroku) - `string` - Specify a custom platform name in the [Graphite key](#metrics)
 * `instance` (optional, default: dynamically generated string) - `string|boolean` - Specify a custom instance name in the [Graphite key](#metrics), or set to `false` to omit it
 * `useDefaultAggregators` (optional, default: true) - `boolean` - Set to `false` if you want to disable default aggregators
+* [DEPRECATED] `app` (required) - `string` - Application name e.g. router
+* [DEPRECATED] `platform` (optional, default: heroku) - `string` - Specify a custom platform name in the [Graphite key](#metrics)
 
 ### Checking configuration
 

--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -36,12 +36,12 @@ Graphite.prototype.log = function (metrics) {
 		return Math.floor(index / 20);
 	});
 
-	const { port, host, key } = this.destination;
+	const { port, host } = this.destination;
 
 	const socket = net.createConnection(port, host, function () {
 		logger.debug({ event: 'NEXT_METRICS_GRAPHITE_CLIENT_CONNECTED', host });
 		_.forEach(dataChunks, (chunk) => {
-			socket.write(chunk.map(chunk => key + chunk).join('\n') + '\n'); // trailing \n to ensure the last metric is registered
+			socket.write(chunk.join('\n') + '\n'); // trailing \n to ensure the last metric is registered
 		});
 		socket.end();
 	});

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -109,7 +109,7 @@ Metrics.prototype.init = function (opts) {
 		prefixKeys.push(instanceKey);
 	}
 
-	const prefix = `${prefixKeys.join('.')}.`;
+	const prefix = prefixKeys.join('.') + '.';
 
 	let noLog = false;
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -15,8 +15,7 @@ lots of additional statements.
 
 */
 
-// The trailing slash is important...
-const Proxies = require('./metrics/');
+const Proxies = require('./metrics/index.js');
 
 const _ = require('lodash');
 const Graphite = require('../lib/graphite/client');

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -48,7 +48,6 @@ Metrics.prototype.init = function (opts) {
 	let hasValidConfiguration = true;
 
 	const FT_GRAPHITE_APP_UUID = process.env.FT_GRAPHITE_APP_UUID;
-	const FT_LEGACY_GRAPHITE_KEY = process.env.HOSTEDGRAPHITE_APIKEY; // Yes, I mean this.
 
 	const isProduction = (process.env.NODE_ENV === 'production');
 	const disableGraphiteMetrics = (FT_GRAPHITE_APP_UUID && FT_GRAPHITE_APP_UUID === 'false');
@@ -120,8 +119,8 @@ Metrics.prototype.init = function (opts) {
 		}));
 	} else {
 
-		// Note: GraphiteV2 automatically prefixes all metrics for individual applications.
-		// That is, each GraphiteV2 UUID has a unique, hard-codec prefix; e.g. `next.heroku.front-page.`
+		// Note: FT GraphiteV2 automatically prefixes all metrics for individual applications.
+		// That is, each FT GraphiteV2 UUID has a unique, hard-codec prefix; e.g. `next.heroku.front-page.`
 		// So if the `destination` is "graphitev2.ft.com", we remove that hard-coded part from the prefix.
 		// See: https://github.com/Financial-Times/next/issues/171
 		this.graphites.push(new Graphite({
@@ -129,14 +128,6 @@ Metrics.prototype.init = function (opts) {
 			prefix: prefix.replace(`.${platform}.${this.opts.app}`, ''), // See above comment
 			noLog,
 		}));
-
-		if (FT_LEGACY_GRAPHITE_KEY && FT_LEGACY_GRAPHITE_KEY !== 'false') {
-			this.graphites.push(new Graphite({
-				destination: { host: 'graphite.ft.com', port: 2003, key: FT_LEGACY_GRAPHITE_KEY },
-				prefix,
-				noLog,
-			}));
-		}
 	}
 
 	this.hasValidConfiguration = hasValidConfiguration;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -68,21 +68,23 @@ Metrics.prototype.init = function (opts) {
 	}
 
 	/**
-	 * Metric Prefixes
+	 * How metric prefixes work with FT GraphiteV2
 	 *
-	 * Every FT GraphiteV2 UUID has a unique prefix associated with it:
+	 * Prefix we send to FT GraphiteV2:
+	 * 63134cae-192b-42be-90b8-c56724a3972d.web_1_process_cluster_worker_1_EU.
+	 * (<uuid>.<instance>.)
 	 *
-	 * FT GraphiteV2 UUID prefix: <team>.<platform>.<application>.
-	 * e.g. next.heroku.front-page.
+	 * FT GraphiteV2 uses the UUID to authenticate the request sent by the app
+	 * that is using `next-metrics`. It also replaces the UUID in the prefix
+	 * that we've sent with a unique pattern that it has associated with the UUID
+	 * when the app was registered with FT GraphiteV2, so the prefix we send
+	 * becomes:
 	 *
-	 * next-metrics metric prefix: .<instance>.
-	 * e.g. web_1_process_cluster_worker_1_EU.
-	 *
-	 * Full metric prefix: <team>.<platform>.<application>.<instance>.
-	 * e.g. next.heroku.front-page.web_1_process_cluster_worker_1_EU.
+	 * next.heroku.front-page.web_1_process_cluster_worker_1_EU.
+	 * (<team>.<platform>.<application>.<instance>.)
 	 */
 
-	const prefixKeys = [];
+	const prefixKeys = [FT_GRAPHITE_APP_UUID];
 
 	const disableInstanceKey = (this.opts.instance === false);
 	if (!disableInstanceKey) {
@@ -107,7 +109,7 @@ Metrics.prototype.init = function (opts) {
 		prefixKeys.push(instanceKey);
 	}
 
-	const prefix = (prefixKeys.length) ? `.${prefixKeys.join('.')}.` : '.';
+	const prefix = `${prefixKeys.join('.')}.`;
 
 	let noLog = false;
 
@@ -129,8 +131,7 @@ Metrics.prototype.init = function (opts) {
 		this.graphites.push(new Graphite({
 			destination: {
 				host: 'graphitev2.ft.com',
-				port: 2003,
-				key: FT_GRAPHITE_APP_UUID
+				port: 2003
 			},
 			prefix,
 			noLog,

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -52,10 +52,10 @@ Metrics.prototype.init = function (opts) {
 	const disableGraphiteMetrics = (FT_GRAPHITE_APP_UUID && FT_GRAPHITE_APP_UUID === 'false');
 	const noValidGraphiteAppUuid = (!FT_GRAPHITE_APP_UUID);
 
-	if (!this.opts.app) {
-		hasValidConfiguration = false;
-		logger.error({ event: 'NEXT_METRICS_INVALID_APP_NAME', message: 'You need to specify an application name in the configuration options. See the next-metrics README: https://github.com/Financial-Times/next-metrics' });
+	if (this.opts.app) {
+		logger.warn({ event: 'NEXT_METRICS_DEPRECATED_OPTION_APP', message: 'The option \'app\' is deprecated and no longer used by next-metrics' });
 	}
+
 	if (!disableGraphiteMetrics && isProduction && noValidGraphiteAppUuid) {
 		hasValidConfiguration = false;
 		logger.error({ event: 'NEXT_METRICS_INVALID_PRODUCTION_CONFIG', message: 'The environment variable FT_GRAPHITE_APP_UUID must be explicitly set to \'false\' if you don\'t wish to send metrics to FT\'s internal Graphite' });
@@ -64,41 +64,42 @@ Metrics.prototype.init = function (opts) {
 		logger.info({ event: 'NEXT_METRICS_DISABLED', message: 'FT_GRAPHITE_APP_UUID is set to \'false\', metrics will not be sent to FT\'s internal Graphite' });
 	}
 
-
 	/**
-	* Metrix Prefix: <platform>.<application>.<instance>.
-	* E.g. <heroku>.<front-page>.<web_1_process_cluster_worker_1_EU>.
-	*/
-	const platform = this.opts.platform || ((process.env.DYNO) ? 'heroku' : 'localhost');
+	 * Metric Prefixes
+	 *
+	 * Every FT GraphiteV2 UUID has a unique prefix associated with it:
+	 *
+	 * FT GraphiteV2 UUID prefix: <team>.<platform>.<application>.
+	 * e.g. next.heroku.front-page.
+	 *
+	 * next-metrics metric prefix: .<instance>.
+	 * e.g. web_1_process_cluster_worker_1_EU.
+	 *
+	 * Full metric prefix: <team>.<platform>.<application>.<instance>.
+	 * e.g. next.heroku.front-page.web_1_process_cluster_worker_1_EU.
+	 */
 
-	// "Platform" and "app" are mandatory in the metrics prefix.
-	let prefixKeys = [platform, this.opts.app];
+	let prefix = '.';
 
-	// "Instance" is *not* mandatory in the metrics prefix.
+	// 'instance' is *not* mandatory in the metrics prefix
 	if (this.opts.instance !== false) {
-
-		// e.g. "next.heroku.front-page.web_1", "next.heroku.front-page.web_2", etc.
+		const platform = this.opts.platform || ((process.env.DYNO) ? 'heroku' : 'localhost');
+		// e.g. "web_1"
 		let instance = this.opts.instance || (platform === 'heroku') ? process.env.DYNO.replace('.', '_') : '_';
-
-		// e.g. "next.heroku.front-page.web_1_process_cluster_worker_1"
 		if (process.env.NODE_APP_INSTANCE) {
+			// e.g. "web_1_process_cluster_worker_1"
 			instance += '_process_' + process.env.NODE_APP_INSTANCE;
 		}
-
-		// e.g. "next.heroku.front-page.web_1_process_cluster_worker_1_EU"
 		if (process.env.REGION) {
+			// e.g. "web_1_process_cluster_worker_1_EU"
 			instance += '_' + process.env.REGION;
 		}
-
-		// e.g. "next.heroku.front-page.web_1_process_cluster_worker_1_EU_canary"
 		if (process.env.FT_APP_VARIANT && process.env.FT_APP_VARIANT === 'canary') {
+			// e.g. "web_1_process_cluster_worker_1_EU_canary"
 			instance += '_canary';
 		}
-
-		prefixKeys.push(instance);
+		prefix += `${instance}.`;
 	}
-
-	const prefix = '.' + prefixKeys.join('.') + '.';
 
 	let noLog = false;
 
@@ -117,14 +118,13 @@ Metrics.prototype.init = function (opts) {
 			noLog,
 		}));
 	} else {
-
-		// Note: FT GraphiteV2 automatically prefixes all metrics for individual applications.
-		// That is, each FT GraphiteV2 UUID has a unique, hard-codec prefix; e.g. `next.heroku.front-page.`
-		// So if the `destination` is "graphitev2.ft.com", we remove that hard-coded part from the prefix.
-		// See: https://github.com/Financial-Times/next/issues/171
 		this.graphites.push(new Graphite({
-			destination: { host: 'graphitev2.ft.com', port: 2003, key: FT_GRAPHITE_APP_UUID },
-			prefix: prefix.replace(`.${platform}.${this.opts.app}`, ''), // See above comment
+			destination: {
+				host: 'graphitev2.ft.com',
+				port: 2003,
+				key: FT_GRAPHITE_APP_UUID
+			},
+			prefix,
 			noLog,
 		}));
 	}

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -55,6 +55,9 @@ Metrics.prototype.init = function (opts) {
 	if (this.opts.app) {
 		logger.warn({ event: 'NEXT_METRICS_DEPRECATED_OPTION_APP', message: 'The option \'app\' is deprecated and no longer used by next-metrics' });
 	}
+	if (this.opts.platform) {
+		logger.warn({ event: 'NEXT_METRICS_DEPRECATED_OPTION_PLATFORM', message: 'The option \'platform\' is deprecated and no longer used by next-metrics' });
+	}
 
 	if (!disableGraphiteMetrics && isProduction && noValidGraphiteAppUuid) {
 		hasValidConfiguration = false;
@@ -79,27 +82,32 @@ Metrics.prototype.init = function (opts) {
 	 * e.g. next.heroku.front-page.web_1_process_cluster_worker_1_EU.
 	 */
 
-	let prefix = '.';
+	const prefixKeys = [];
 
-	// 'instance' is *not* mandatory in the metrics prefix
-	if (this.opts.instance !== false) {
-		const platform = this.opts.platform || ((process.env.DYNO) ? 'heroku' : 'localhost');
+	const disableInstanceKey = (this.opts.instance === false);
+	if (!disableInstanceKey) {
+		const platformIsHeroku = !!process.env.DYNO;
+
 		// e.g. "web_1"
-		let instance = this.opts.instance || (platform === 'heroku') ? process.env.DYNO.replace('.', '_') : '_';
+		let instanceKey = this.opts.instance || (platformIsHeroku === 'heroku') ? process.env.DYNO.replace('.', '_') : '_';
+
 		if (process.env.NODE_APP_INSTANCE) {
 			// e.g. "web_1_process_cluster_worker_1"
-			instance += '_process_' + process.env.NODE_APP_INSTANCE;
+			instanceKey += '_process_' + process.env.NODE_APP_INSTANCE;
 		}
 		if (process.env.REGION) {
 			// e.g. "web_1_process_cluster_worker_1_EU"
-			instance += '_' + process.env.REGION;
+			instanceKey += '_' + process.env.REGION;
 		}
 		if (process.env.FT_APP_VARIANT && process.env.FT_APP_VARIANT === 'canary') {
 			// e.g. "web_1_process_cluster_worker_1_EU_canary"
-			instance += '_canary';
+			instanceKey += '_canary';
 		}
-		prefix += `${instance}.`;
+
+		prefixKeys.push(instanceKey);
 	}
+
+	const prefix = (prefixKeys.length) ? `.${prefixKeys.join('.')}.` : '.';
 
 	let noLog = false;
 

--- a/lib/metrics/system/process.js
+++ b/lib/metrics/system/process.js
@@ -1,5 +1,4 @@
 /*eslint new-cap: 1, no-extend-native: 1*/
-/* jshint -W079 */
 const _ = require('lodash');
 const os = require('os');
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "eslint": "^5.2.0",
     "express": "^4.13.3",
     "ft-api-client": "https://github.com/Financial-Times/ft-api-client/archive/emit-events.tar.gz",
-    "jshint": "*",
     "lintspaces-cli": "^0.6.1",
     "mitm": "1.2.0",
     "mocha": "^5.2.0",

--- a/secret-squirrel.js
+++ b/secret-squirrel.js
@@ -1,14 +1,12 @@
 module.exports = {
 	files: {
-		allow: [
-			'TODO'
-		],
+		allow: [],
 		allowOverrides: []
 	},
 	strings: {
 		deny: [],
 		denyOverrides: [
-			'd3fe0b06-9e43-11e3-b429-00144feab7de' // README.md:96|97|98
+			'63134cae-192b-42be-90b8-c56724a3972d' // lib/metrics.js:74
 		]
 	}
 };

--- a/test/unit/client.spec.old.js
+++ b/test/unit/client.spec.old.js
@@ -35,8 +35,7 @@ describe('Logging to graphite', function () {
 		const g = new Graphite({
 			destination: {
 				port: 2003,
-				host: 'test.host.com',
-				key: 'k.'
+				host: 'test.host.com'
 			},
 			prefix: 'p.',
 			noLog: false

--- a/test/unit/client.spec.old.js
+++ b/test/unit/client.spec.old.js
@@ -28,7 +28,7 @@ describe('Logging to graphite', function () {
 	it('Send metrics to Graphite', function (done) {
 		this.mitm.on('connection', function (socket) {
 			socket.on('data', function (d) {
-				expect(d.toString('utf-8')).to.equal('k.p.a 1 1434399121\nk.p.b 2 1434399121\n');
+				expect(d.toString('utf-8')).to.equal('p.a 1 1434399121\np.b 2 1434399121\n');
 				done();
 			});
 		});

--- a/test/unit/http.spec.old.js
+++ b/test/unit/http.spec.old.js
@@ -18,7 +18,7 @@ describe('Http metrics', function () {
 	beforeEach(function () {
 		clock = sinon.useFakeTimers();
 		metrics = new Metrics();
-		metrics.init({ app: 'test', flushEvery: 100 });
+		metrics.init({ flushEvery: 100 });
 		app = express();
 
 		app.use(function (req, res, next) {

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -191,7 +191,7 @@ describe('lib/metrics', () => {
 			beforeEach(() => {
 				process.env.NODE_ENV = 'production';
 				process.env.FT_GRAPHITE_APP_UUID = 'mock-hosted-uuid-env';
-				instance.init({ ...options, app: 'front-page' });
+				instance.init(Object.assign({}, options, { app: 'front-page' }));
 			});
 
 			it('a warn message with the event NEXT_METRICS_DEPRECATED_OPTION_APP should be logged', () => {
@@ -207,7 +207,7 @@ describe('lib/metrics', () => {
 			beforeEach(() => {
 				process.env.NODE_ENV = 'production';
 				process.env.FT_GRAPHITE_APP_UUID = 'mock-hosted-uuid-env';
-				instance.init({ ...options, platform: 'heroku' });
+				instance.init(Object.assign({}, options, { platform: 'heroku' }));
 			});
 
 			it('a warn message with the event NEXT_METRICS_DEPRECATED_OPTION_PLATFORM should be logged', () => {

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -40,9 +40,7 @@ describe('lib/metrics', () => {
 
 		beforeEach(() => {
 			options = {
-				app: 'front-page',
 				useDefaultAggregators: false,
-				platform: 'heroku',
 				instance: 'web_1_process_cluster_worker_1_EU',
 			};
 
@@ -188,6 +186,38 @@ describe('lib/metrics', () => {
 			});
 			it('metric logging should be disabled for the Graphite client (opts.noLog)', () => {
 				assert.isTrue(Graphite.firstCall.args[0].noLog);
+			});
+
+		});
+
+		describe('when `app` option is passed to Metrics#init', () => {
+
+			beforeEach(() => {
+				process.env.NODE_ENV = 'production';
+				process.env.FT_GRAPHITE_APP_UUID = 'mock-hosted-uuid-env';
+				instance.init({ ...options, app: 'front-page' });
+			});
+
+			it('a warn message with the event NEXT_METRICS_DEPRECATED_OPTION_APP should be logged', () => {
+				assert.calledOnce(nLogger.default.warn);
+				assert.isObject(nLogger.default.warn.firstCall.args[0]);
+				assert.equal(nLogger.default.warn.firstCall.args[0].event, 'NEXT_METRICS_DEPRECATED_OPTION_APP');
+			});
+
+		});
+
+		describe('when `platform` option is passed to Metrics#init', () => {
+
+			beforeEach(() => {
+				process.env.NODE_ENV = 'production';
+				process.env.FT_GRAPHITE_APP_UUID = 'mock-hosted-uuid-env';
+				instance.init({ ...options, platform: 'heroku' });
+			});
+
+			it('a warn message with the event NEXT_METRICS_DEPRECATED_OPTION_PLATFORM should be logged', () => {
+				assert.calledOnce(nLogger.default.warn);
+				assert.isObject(nLogger.default.warn.firstCall.args[0]);
+				assert.equal(nLogger.default.warn.firstCall.args[0].event, 'NEXT_METRICS_DEPRECATED_OPTION_PLATFORM');
 			});
 
 		});

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -81,12 +81,8 @@ describe('lib/metrics', () => {
 				assert.equal(Graphite.firstCall.args[0].destination.host, 'graphitev2.ft.com');
 			});
 
-			it('the Graphite API key should be passed to the Graphite client (opts.destination.key)', () => {
-				assert.equal(Graphite.firstCall.args[0].destination.key, 'mock-hosted-uuid-env');
-			});
-
 			it('the correct prefix should be passed to the Graphite client (opts.prefix)', () => {
-				assert.equal(Graphite.firstCall.args[0].prefix, '.web_1_process_cluster_worker_1_EU.');
+				assert.equal(Graphite.firstCall.args[0].prefix, 'mock-hosted-uuid-env.web_1_process_cluster_worker_1_EU.');
 			});
 
 			it('metric logging should be enabled for the Graphite client (opts.noLog)', () => {

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -48,12 +48,10 @@ describe('lib/metrics', () => {
 
 			originalEnv = {
 				FT_GRAPHITE_APP_UUID: process.env.FT_GRAPHITE_APP_UUID,
-				HOSTEDGRAPHITE_APIKEY: process.env.HOSTEDGRAPHITE_APIKEY,
 				NODE_ENV: process.env.NODE_ENV
 			};
 
 			delete process.env.FT_GRAPHITE_APP_UUID;
-			delete process.env.HOSTEDGRAPHITE_APIKEY;
 
 			process.env.NODE_ENV = 'test';
 			process.env.DYNO = 'web.1';
@@ -65,7 +63,6 @@ describe('lib/metrics', () => {
 
 		afterEach(() => {
 			process.env.FT_GRAPHITE_APP_UUID = originalEnv.FT_GRAPHITE_APP_UUID;
-			process.env.HOSTEDGRAPHITE_APIKEY = originalEnv.HOSTEDGRAPHITE_APIKEY;
 			process.env.NODE_ENV = originalEnv.NODE_ENV;
 		});
 
@@ -96,43 +93,6 @@ describe('lib/metrics', () => {
 
 			it('metric logging should be enabled for the Graphite client (opts.noLog)', () => {
 				assert.isFalse(Graphite.firstCall.args[0].noLog);
-			});
-
-		});
-
-		describe('when the FT_GRAPHITE_APP_UUID and HOSTEDGRAPHITE_APIKEY environment variable is set and NODE_ENV is "production"', () => {
-
-			beforeEach(() => {
-				process.env.NODE_ENV = 'production';
-				process.env.FT_GRAPHITE_APP_UUID = 'mock-hosted-uuid-env';
-				process.env.HOSTEDGRAPHITE_APIKEY = 'mock-hosted-apikey-env';
-				instance.init(options);
-			});
-
-			it('two Graphite clients should be instantiated', () => {
-				assert.calledTwice(Graphite);
-				assert.isObject(Graphite.firstCall.args[0]);
-				assert.isObject(Graphite.secondCall.args[0]);
-			});
-
-			it('the Graphite hosts should be passed to the Graphite clients correctly', () => {
-				assert.equal(Graphite.firstCall.args[0].destination.host, 'graphitev2.ft.com');
-				assert.equal(Graphite.secondCall.args[0].destination.host, 'graphite.ft.com');
-			});
-
-			it('the correct prefixes should be passed to the Graphite clients (opts.prefix)', () => {
-				assert.equal(Graphite.firstCall.args[0].prefix, '.web_1_process_cluster_worker_1_EU.');
-				assert.equal(Graphite.secondCall.args[0].prefix, '.heroku.front-page.web_1_process_cluster_worker_1_EU.');
-			});
-
-			it('the Graphite API keys should be passed to the Graphite clients (opts.destination.key)', () => {
-				assert.equal(Graphite.firstCall.args[0].destination.key, 'mock-hosted-uuid-env');
-				assert.equal(Graphite.secondCall.args[0].destination.key, 'mock-hosted-apikey-env');
-			});
-
-			it('metric logging should be enabled for the Graphite clients (opts.noLog)', () => {
-				assert.isFalse(Graphite.firstCall.args[0].noLog);
-				assert.isFalse(Graphite.secondCall.args[0].noLog);
 			});
 
 		});


### PR DESCRIPTION
FT Graphite (`graphite.ft.com`) no longer exists, so we're removing support for it and optimising this library for FT GraphiteV2.

The `Metrics#init` options `app` and `platform` have been deprecated. Warning messages will be logged if either of these options are specified when calling the `init` method.

Resolves #315.