### PR TITLE
Fix platformIsHeroku comparing boolean to string 'heroku' bug

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,13 +22,13 @@ references:
 
   npm_cache_keys: &npm_cache_keys
     keys:
-        - v1-dependency-npm-{{ checksum "package.json" }}-
-        - v1-dependency-npm-{{ checksum "package.json" }}
-        - v1-dependency-npm-
+        - v2-dependency-npm-{{ checksum "package.json" }}-
+        - v2-dependency-npm-{{ checksum "package.json" }}
+        - v2-dependency-npm-
 
   cache_npm_cache: &cache_npm_cache
     save_cache:
-        key: v1-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
+        key: v2-dependency-npm-{{ checksum "package.json" }}-{{ epoch }}
         paths:
         - ./node_modules/
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -91,10 +91,9 @@ Metrics.prototype.init = function (opts) {
 
 	const disableInstanceKey = (this.opts.instance === false);
 	if (!disableInstanceKey) {
-		const platformIsHeroku = !!process.env.DYNO;
 
 		// e.g. "web_1"
-		let instanceKey = this.opts.instance || (platformIsHeroku === 'heroku') ? process.env.DYNO.replace('.', '_') : '_';
+		let instanceKey = this.opts.instance || process.env.DYNO ? process.env.DYNO.replace('.', '_') : '_';
 
 		if (process.env.NODE_APP_INSTANCE) {
 			// e.g. "web_1_process_cluster_worker_1"


### PR DESCRIPTION
# Fix platformIsHeroku comparing boolean to string 'heroku' bug

## What
- A variable had been updated from being a string with a potential value of `'heroku'` to being a `Boolean`, however the usage of the variable had been missed. This PR corrects and inlines the boolean comparison for simplification.

## Why
This was preventing the correct metrics being posted