### PR TITLE
Fix ternary statement for setting instanceKey

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -93,7 +93,7 @@ Metrics.prototype.init = function (opts) {
 	if (!disableInstanceKey) {
 
 		// e.g. "web_1"
-		let instanceKey = this.opts.instance || process.env.DYNO ? process.env.DYNO.replace('.', '_') : '_';
+		let instanceKey = this.opts.instance || (process.env.DYNO ? process.env.DYNO.replace('.', '_') : '_');
 
 		if (process.env.NODE_APP_INSTANCE) {
 			// e.g. "web_1_process_cluster_worker_1"


### PR DESCRIPTION
If opts.instance is provided, it is ignored in favour of the env.DYNO value.

If this is run locally, without the env variable being set, it crashes as it always tries to apply the .replace calll due the way the order of precedence is evaluated.