### PR TITLE
clear custom histo after flushing

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -200,6 +200,7 @@ Metrics.prototype.flushCustomHistograms = function () {
 		obj[key + '.95th'] = percentiles[0.95];
 		obj[key + '.99th'] = percentiles[0.99];
 		obj[key + '.count'] = histo.count;
+		histo.clear();
 	});
 	return obj;
 };


### PR DESCRIPTION
Well, this is embarrassing @matthew-andrews @commuterjoy 

Meant any histograms (other than fetch and express request ones) accumulated over the lifetime of the process. Memory leak + so, so wrong

How did next survive so long with this bug 🤣 

 🐿 v2.12.0