### PR TITLE
Fixed init method behaviour when multiple init calls are made

### DIFF
--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -37,7 +37,7 @@ const Metrics = function () {
 };
 
 Metrics.prototype.init = function (opts) {
-	if (this.graphite) {
+	if (this.graphites.length > 0) {
 		logger.warn({ event: 'NEXT_METRICS_ALREADY_CONFIGURED', message: 'Already configured, not re-initialising' });
 		return;
 	}

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -148,6 +148,16 @@ describe('lib/metrics', () => {
 
 		});
 
+		describe('when init method runs', () => {
+			it('a warn message with the event NEXT_METRICS_ALREADY_CONFIGURED should be logged', () => {
+				instance.init(Object.assign({}, options));
+				instance.init(Object.assign({}, options));
+				assert.calledOnce(nLogger.default.warn);
+				assert.isObject(nLogger.default.warn.firstCall.args[0]);
+				assert.equal(nLogger.default.warn.firstCall.args[0].event, 'NEXT_METRICS_ALREADY_CONFIGURED');
+			});
+		});
+
 		describe('when the FT_GRAPHITE_APP_UUID environment variable is set in a non-production environment', () => {
 
 			beforeEach(() => {


### PR DESCRIPTION
There were some issues when multiple init calls were made. After some investigation I saw that multiple aggregators were added with each init call, which led to custom counter overrides. It seems that was caused by `if(this.graphite)` being `undefined`. this.graphite was used before `this.graphites = [];` was introduced. 
This PR should fix the issue