### PR TITLE
Add next-preview test api url in services.js

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -21,6 +21,7 @@ module.exports = {
 	'api-gtg': /^https?:\/\/api\.ft\.com\/__gtg/,
 	'api-licences': /^https?:\/\/api\.ft\.com\/licences/,
 	'api-internalcontent-preview': /^https?:\/\/api\.ft\.com\/internalcontent-preview/,
+	'api-internalcontent-preview-test': /^https?:\/\/test\.api\.ft\.com\/internalcontent/,
 	'alphaville': /^https?:\/\/ftalphaville\.ft\.com/,
 	'anon-email-list-api': /https:\/\/anon-email-lists-eu-(prod|test)\.herokuapp\.com/,
 	'asana': /^https:\/\/app\.asana\.com\//,


### PR DESCRIPTION
A next-preview healthcheck is failing

```js
{
	"name": "Metrics: All services for preview registered in next-metrics",
	"ok": false,
	"checkOutput": "http://test.api.ft.com/internalcontent/42215589-eee1-399f-97ee-c71f61462eb4, http://test.api.ft.com/internalcontent/a65384bb-5017-3184-9e1d-742fb1000ba1, http://test.api.ft.com/internalcontent/31ba72c7-19ec-3bdf-8a1d-a36ec48796e6, http://test.api.ft.com/internalcontent/30649a3b-3139-3c27-a806-6b65df216b80, http://test.api.ft.com/internalcontent/ed8dff25-0110-384f-82fd-d03780d6ec9, http://test.api.ft.com/internalcontent/b03f7d6f-decd-3fbc-9c7b-870794610825 services called but no metrics set up.",
	"lastUpdated": "2019-09-04T13:53:39.630Z",
	"panicGuide": "See next-metrics/lib/metrics/services.js and set metrics for the service, then release next-metrics and rebuild this app.",
	"severity": 3,
	"businessImpact": "We don't have any visibility with unregistered services.",
	"technicalSummary": "Set up services' metrics in next-metrics/lib/metrics/services.js to send to Graphite."
},
```
The conversation about whether it is ok to add http://test.api.ft.com/ in next-metrics
https://financialtimes.slack.com/archives/C041V9QA7/p1567511176110900