### PR TITLE
modify circleci node version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ references:
   container_config_node8: &container_config_node8
     working_directory: ~/project/build
     docker:
-      - image: circleci/node:6-browsers
+      - image: circleci/node:6.17.1-browsers
 
   container_config_lambda_node8: &container_config_lambda_node8
     working_directory: ~/project/build


### PR DESCRIPTION
To see whether it fix this error which happens when it release new version.
```
#!/bin/bash -eo pipefail
npx snyk monitor --org=customer-products --project-name=Financial-Times/next-metrics
/bin/bash: npx: command not found
Exited with code 127 
```
https://circleci.com/gh/Financial-Times/next-metrics/2238

🐿 v2.12.4