### PR TITLE
Update personlised-feed service URL

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -102,7 +102,7 @@ module.exports = {
 	'ft-next-markets-proxy-api': /^https?:\/\/markets-data-api-proxy\.ft\.com/,
 	'ft-next-myft-api': /https?\:\/\/ft-next-myft-api\.herokuapp\.com/,
 	'ft-next-myft-api-test': /https?\:\/\/ft-next-myft-api-test\.herokuapp\.com/,
-	'ft-next-personalised-feed-api': /^https?:\/\/(personalised-feed\.ft\.com|ft-next-personalised-feed-api\.herokuapp\.com)\/v\d+\/feed/,
+	'ft-next-personalised-feed-api': /^https?:\/\/(personalised-feed\.ft\.com|ft-next-personalised-feed-api\.herokuapp\.com)\/v\d+\//,
 	'ft-next-popular-api-articles': /https:\/\/ft-next-popular-api\.herokuapp\.com\/articles/,
 	'ft-next-popular-api-concepts': /https:\/\/ft-next-popular-api\.herokuapp\.com\/concepts/,
 	'ft-next-popular-api-topics': /https:\/\/ft-next-popular-api\.herokuapp\.com\/topics/,


### PR DESCRIPTION
Remove `feed` from the service URL as there is now a `country-feed` so this should future proof this a little more.