### PR TITLE
add urls used by eventpromo sync service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -162,6 +162,8 @@ module.exports = {
 	'next-api-canary': /^http:\/\/ft-next-api-canary\.herokuapp\.com\//,
 	'next-b2b-prospect-api': /^https?:\/\/next-b2b-prospect\.ft\.com\/api\/.*/,
 	'next-eventpromo-api': /^https?:\/\/ft-next-eventpromo-api-(eu|us)\.herokuapp\.com/,
+	'next-eventpromo-api-sync': /^https?:\/\/ft\.com\/eventpromo\/sync/,
+	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
 	'next-media-api': /^https?:\/\/next-media-api\.ft\.com\/renditions\/.*/,
 	'next-session-lambda': /https?:\/\/[^\.]+.execute-api.eu-west-1.amazonaws.com/,


### PR DESCRIPTION
trying to clear heimdall alerts
Metrics: All services for eventpromo-api registered in next-metrics

heimdall
https://heimdall.in.ft.com/system?code=next-eventpromo-api#monitored-checks-list

ops-cops card:
https://trello.com/c/PZC87usn/1163-eventpromo-api-alerting
