### PR TITLE
Set up metrics for Origami Build Service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -175,6 +175,8 @@ module.exports = {
 	'offer-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'ombudsman': /^https?:\/\/ombudsman\.in\.ft\.com/,
 	'ontotext-popular': /^https:\/\/api\.ft\.com\/recommended-reads-api\/recommend\/popular/,
+	'origami-build-service-v1': /^https?:\/\/www\.ft\.com\/__origami\/service\/image\/v1/,
+	'origami-build-service-v2': /^https?:\/\/www\.ft\.com\/__origami\/service\/image\/v2/,
 	'pac': /^https?:\/\/api\.ft\.com\/drafts\/content/,
 	'paymentpage2': /^https:\/\/subscription-api-gw-eu-west-1-prod.memb.ft.com\/paymentpage2\/[\w\-\/]+/,
 	'paymentpage2-test': /^https:\/\/subscription-api-gw-eu-west-1-test.memb.ft.com\/paymentpage2\//,


### PR DESCRIPTION
Previously, we had an `www.ft.com` service which acted as a catch-all service but it hid key information. `www.ft.com` was recently removed from the list (see commit https://github.com/Financial-Times/next-metrics/commit/2a0b3e303e6b96fa6bd7b99960badc6f13df8533) in favour of adding more specific APIs and services (e.g. `www.ft.com/content/*`).

Since then we've come across an error about `https://www.ft.com/__origami/service/image/v2/ ` not being registered in `next-metrics`. This PR adds it to the list of services. 

I've also added Origami Build Service v1 to the list, as Sam suggested, so we can find out where we need to update things

Resolves Ops Cop issue: https://trello.com/c/Y2VRF2wp/1220-metrics-all-services-for-es-interface-registered-in-next-metrics-alert