### PR TITLE
Set up metrics for next-syn-list

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -170,6 +170,7 @@ module.exports = {
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
 	'next-media-api': /^https?:\/\/next-media-api\.ft\.com\/renditions\/.*/,
 	'next-session-lambda': /https?:\/\/[^\.]+.execute-api.eu-west-1.amazonaws.com/,
+	'next-syn-list': /^https?:\/\/www.ft.com\/syndication/,
 	'n-ui-assets': /ft-next-n-ui-prod(-us)?\.s3-website-(eu-west|us-east)-1\.amazonaws\.com\/__assets\/n-ui/,
 	'offer-api': /^https:\/\/(beta-)?api\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'offer-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,


### PR DESCRIPTION
Previously, we had an `www.ft.com` service which acted as a catch-all service but it hid key information. `www.ft.com` was recently removed from the list (see commit https://github.com/Financial-Times/next-metrics/commit/2a0b3e303e6b96fa6bd7b99960badc6f13df8533) in favour of adding more specific APIs and services (e.g. `www.ft.com/content/*`).

Since then we've come across an error about `https://www.ft.com/syndication` not being registered in next-metrics. This PR adds it to the list of services.

Once this PR is merged, I will have to create a new release in both `n-express` and `n-ui` in order for the change to get picked up.

Resolves Ops Cop issue: https://trello.com/c/ngq2Wqwi/1259-next-syn-list-is-flappy