### PR TITLE
chore: remove decommed article-email metric

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -254,7 +254,6 @@ module.exports = {
 	'video': /https?:\/\/next-video\.ft\.com/,
 	'video-whakataki-lambda-things': /^https:\/\/thing-videotest\.ft\.com\/things/,
 	'www-article': /https:\/\/www\.ft\.com\/content\/.+/,
-	'next-article-email-api': /https:\/\/www\.ft\.com\/article-email\/.+/,
 	'zuora-system-status': /trust\.zuora\.com/, // used in next-signup healthchecks
 	// white-label consent & cookie metrics for Specialist Titles
 	// we need them here to silence the "We don't have any visibility with unregistered services" healthchecks


### PR DESCRIPTION
As the article-email API has now been removed from `next-article` and `service-registry`, we shouldn't have any need for the metric to hang around either.