### PR TITLE
Remove mship-mock-api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -153,7 +153,6 @@ module.exports = {
 	'membership-idm-test': /^https:\/\/api-t\.ft\.com\/idm\/v1\/users\//,
 	'membership-invoice': /^https:\/\/invoice-svc-[^\.]+.memb\.ft\.com\/membership\/invoices/,
 	'messaging-guru': /^https:\/\/ft\.com\/__message\/.*/,
-	'mship-mock-api': /^https:\/\/ft-next-mship-mock-api-eu\.herokuapp\.com/,
 	'myft-api': /https?:\/\/myft-api\.ft\.com/,
 	'navigation-api': /next-navigation\.ft\.com/,
 	'navigation-eu-bucket': /ft-next-navigation\.s3-website-eu-west-1\.amazonaws\.com/,


### PR DESCRIPTION
This is no longer used and as part of decommissioning `next-signup` we're removing this.

[Trello ticket](https://trello.com/c/CkV91VXy/1696-decommission-next-signup-and-next-signup-api)