### PR TITLE
Remove the need for a backslash at end of url

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -146,7 +146,7 @@ module.exports = {
 	'markets': /^https?:\/\/markets\.ft\.com/,
 	'maxmind-download': /http:\/\/download\.maxmind\.com/,
 	'maxmind-prod-api': /^https:\/\/spoor-maxmind-api\.ft\.com/,
-	'membership-graphql': /^https:\/\/api.ft.com\/memb-query\/api\//,
+	'membership-graphql': /^https:\/\/api.ft.com\/memb-query\/api/,
 	'membership-graphql-glb': /^https:\/\/memb-graphql-api-glb-prod\.memb\.ft\.com/,
 	'membership-graphql-test-glb': /^https:\/\/memb-graphql-api-glb-test\.memb\.ft\.com/,
 	'membership-idm': /^https:\/\/api\.ft\.com\/idm\/v1\/users\//,


### PR DESCRIPTION
`next-comments-api` calls the membership graphql service without a
backslash and as a result, it's healthcheck was failing. This PR removes
the need for a backslash so regardless of whether you use one or not,
`next-metrics` will pick it up.