### PR TITLE
add Bitly v4 to the services list

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -35,7 +35,7 @@ module.exports = {
 	'barriers-guru-corporate-api': /^https?:\/\/barrier-guru\.ft\.com\/corporate/,
 	'barrier-guru-api': /^https?:\/\/barrier-guru\.ft\.com\/barrier/,
 	'bertha': /^https?:\/\/bertha\.ig\.ft\.com/,
-	'bitly': /^https:\/\/api-ssl\.bitly\.com\/v3\/shorten/,
+	'bitly': /^https:\/\/api-ssl\.bitly\.com\/v[34]\/shorten/,
 	'blogs': /^https?:\/\/blogs\.ft\.com/,
 	'brightcove': /^https?:\/\/api\.brightcove\.com\/services\/library/,
 	'brightcove-v2-cms': /^https:\/\/cms\.api\.brightcove\.com\//,


### PR DESCRIPTION
next article has a failing health check:

`"checkOutput": "https://api-ssl.bitly.com/v4/shorten services called but no metrics set up."`

this PR will hopefully fix that

see https://github.com/Financial-Times/next-article/pull/3679