### PR TITLE
Add Salesforce APIs to list of instrumented services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -206,6 +206,8 @@ module.exports = {
 	'redeemable-token-svc-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/redeemable-tokens\/.*/,
 	'rj-capi-mock': /^https:\/\/s3-eu-west-1\.amazonaws\.com\/rj-xcapi-mock\/production\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}(\.json)?/,
 	'rj-up': /^https?:\/\/rj-up\.ft\.com/,
+	'salesforce-auth-api': /^https:\/\/login\.salesforce\.com\/services\/oauth2\/token/,
+	'salesforce-contract-api': /^https:\/\/financialtimes\.my\.salesforce\.com\/services\/apexrest\/SCRMKATContract\/.*/,
 	'sapi': /^https?:\/\/api\.ft\.com\/content\/search\/v1/,
 	'sapi-2': /^https?:\/\/search-services\.ft\.com\/search-services\/search/,
 	'session-api': /^https:\/\/sessionapi\.memb\.ft\.com\/membership\/sessions/,


### PR DESCRIPTION
Salesforce APIs are used in `next-subscribe` to retrieve the associated contract of a B2B licence.