### PR TITLE
Removes reference to next-b2b-prospect

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -172,7 +172,6 @@ module.exports = {
 	'newspaper-subs-api': /https:\/\/sub\.ft\.com\//,
 	'next-api': /^https:\/\/next-api\.ft\.com\//,
 	'next-api-canary': /^http:\/\/ft-next-api-canary\.herokuapp\.com\//,
-	'next-b2b-prospect-api': /^https?:\/\/next-b2b-prospect\.ft\.com\/api\/.*/,
 	'next-eventpromo-api': /^https?:\/\/ft-next-eventpromo-api-(eu|us)\.herokuapp\.com/,
 	'next-eventpromo-api-sync': /^https?:\/\/ft\.com\/eventpromo\/api\/sync/,
 	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,


### PR DESCRIPTION
 🐿 v2.12.4
Work involved in decommissioning next-b2b-prospect