### PR TITLE
Add catch to promise chain

### DIFF
--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -59,7 +59,7 @@ module.exports = class {
 				const response = _fetch.apply(this, arguments);
 				response.then(() => {
 					end = Date.now();
-				});
+				}).catch(() => {}); // empty catch as exceptions are handled in other promise chains
 
 				// take the metrics off the microtask queue
 				setTimeout(() => {


### PR DESCRIPTION
If fetch throws an exception, because for example there is a timeout
exception thrown, then this promise chain wouldn't have had a catch on
it so would have triggered a `unhandledRejection` event. This was
causing enterprise tools to crash when there was a network timeout.

We don't need to actually do anything with this catch though as the
promise chain is only being used for metric collection. The exception
will still bubble through the other promise chains where a consuming
application can handle it properly.