### PR TITLE
Add https://url-management-api.in.ft.com/api to services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -120,6 +120,7 @@ module.exports = {
 	'ft-next-service-registry': /https?:\/\/next-registry\.ft\.com/,
 	'ft-next-session-service': /^https?:\/\/session-next\.ft\.com/,
 	'ft-next-sharedcount-api': /^https?:\/\/ft-next-sharedcount-api\.herokuapp\.com/,
+	'ft-next-url-management-api': /^https:\/\/url-management-api\.in\.ft\.com\/api/,
 	'ft-next-video-editor': /^https:\/\/(next-video-editor\.ft|ft-next-video-editor\.herokuapp)\.com\//,
 	'ft-next-video-editor-publishing': /^https:\/\/publishing-prod-up\.ft\.com/,
 	'ft-next-video-editor-yt-publisher': /^https:\/\/youtube-publisher\.ft\.com\/api/,


### PR DESCRIPTION
As per `panicGuide` for one of the health checks currently failing in: https://url-management.ft.com/__health.

```
{
	"name": "Metrics: All services for url-mgmt-service registered in next-metrics",
	"ok": false,
	"checkOutput": "https://url-management-api.in.ft.com/api services called but no metrics set up.",
	"lastUpdated": "2020-04-21T10:04:12.425Z",
	"panicGuide": "See next-metrics/lib/metrics/services.js and set metrics for the service, then release next-metrics and rebuild this app.",
	"severity": 3,
	"businessImpact": "We don't have any visibility with unregistered services.",
	"technicalSummary": "Set up services' metrics in next-metrics/lib/metrics/services.js to send to Graphite."
},
```

The `next-url-mgmt-service` health checks have now been added to Heimdall (https://heimdall.in.ft.com/system?code=next-url-mgmt-service) so we should make it nice and green.