### PR TITLE
Add next-live-event-notification-poc to the list of services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -179,6 +179,7 @@ module.exports = {
 	'next-eventpromo-api': /^https?:\/\/ft-next-eventpromo-api-(eu|us)\.herokuapp\.com/,
 	'next-eventpromo-api-sync': /^https?:\/\/ft\.com\/eventpromo\/api\/sync/,
 	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,
+	'next-live-event-notification-poc': /^https?:\/\/next-live-event\.ft\.com\/notification-poc\/notification/,
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
 	'next-magnet-api-event-promo': /^https:\/\/www\.ft\.com\/eventpromo\/api.*/,
 	'next-media-api': /^https?:\/\/next-media-api\.ft\.com\/renditions\/.*/,


### PR DESCRIPTION
This endpoint is called by next-es-interface and currently there is a healthcheck error fired because it is not measured by next-metrics.