### PR TITLE
Updates the coronavirus stats endpoint

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -136,7 +136,7 @@ module.exports = {
 	'heroku-api': /^https?:\/\/api\.heroku\.com/,
 	'hui': /^https?:\/\/api\.ft\.com\/hui\//,
 	'hui-content': /^https?:\/\/api\.ft\.com\/hui\/content/,
-	'ig-coronavirus-map': /^https?:\/\/ig.ft.com\/autograph\/graphics\/coronavirus-map\.json/,
+	'ig-coronavirus-map': /^https?:\/\/ig.ft.com\/coronavirus-chart\/data-map-v2__world\.json/,
 	'ig-stream-content': /^https?:\/\/ft-ig-stream-content\.herokuapp\.com\//,
 	'internal-graphite': /^https?:\/\/graphite(v2)?-api\.ft\.com\//,
 	'kat': /^https?:\/\/kat\.ft\.com\/api\//,


### PR DESCRIPTION
Updates the coronavirus stats endpoint to match the new url https://ig.ft.com/coronavirus-chart/data-map-v2__world.json