### PR TITLE
fix: add new access counted content endpoint

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -6,6 +6,7 @@ module.exports = {
 	'access-licence-svc-RETIRED': /^https:\/\/acc-licence-svc-gw-eu-west-1-prod\.memb\.ft\.com\//,
 	'access-licence-svc-RETIRED-test': /^https:\/\/acc-licence-svc-gw-eu-west-1-test\.memb\.ft\.com\//,
 	'access-licence-svc-test': /^https:\/\/(beta-)?api-t\.ft\.com\/licences\//,
+	'access-content-allowance': /^https:\/\/api\.ft\.com\/access\/user\/.*\/counted-content-allowance/,
 	'accounts': /^https?:\/\/accounts\.ft\.com\/.*/,
 	'acq-context-svc': /^https:\/\/(beta-)?api\.ft\.com\/acquisition-contexts\//,
 	'acq-context-svc-test': /^https:\/\/(beta-)?api-t\.ft\.com\/acquisition-contexts\//,


### PR DESCRIPTION
This is a new endpoint exposed by Membership to allow `next-messaging-guru` to display messages containing the remaining count of allowed articles on a user by user basis.

As this is missing, its currently causing the healthchecks to fail (https://heimdall.ftops.tech/system?returnTo=%2Foperations&code=next-messaging-guru#monitored-checks-list)