### PR TITLE
NOPS-346 added next-feedback-api to services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -180,7 +180,7 @@ module.exports = {
 	'next-eventpromo-api': /^https?:\/\/ft-next-eventpromo-api-(eu|us)\.herokuapp\.com/,
 	'next-eventpromo-api-sync': /^https?:\/\/ft\.com\/eventpromo\/api\/sync/,
 	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,
-	'next-feedback-api': /^https:\/\/(www\.)?ft\.com\/__feedback-api\/v1\/survey/,
+	'next-feedback-api': /^https:\/\/(www\.)?ft\.com\/__feedback-api\/.*/,
 	'next-live-event-notification-poc': /^https?:\/\/next-live-event\.ft\.com\/notification-poc\/notification/,
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
 	'next-magnet-api-event-promo': /^https:\/\/www\.ft\.com\/eventpromo\/api.*/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -180,6 +180,7 @@ module.exports = {
 	'next-eventpromo-api': /^https?:\/\/ft-next-eventpromo-api-(eu|us)\.herokuapp\.com/,
 	'next-eventpromo-api-sync': /^https?:\/\/ft\.com\/eventpromo\/api\/sync/,
 	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,
+	'next-feedback-api': /^https:\/\/(www\.)?ft\.com\/__feedback-api\/v1\/survey/,
 	'next-live-event-notification-poc': /^https?:\/\/next-live-event\.ft\.com\/notification-poc\/notification/,
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
 	'next-magnet-api-event-promo': /^https:\/\/www\.ft\.com\/eventpromo\/api.*/,

--- a/test/unit/http.spec.old.js
+++ b/test/unit/http.spec.old.js
@@ -100,14 +100,14 @@ describe('Http metrics', function () {
 		request(app)
 			.get('/__health')
 			.end(() => {
-					clock.tick(100);
-					expect(metrics.graphites[0].log.args[0][0]['express.http.req.count']).to.equal(0);
-					expect(metrics.graphites[0].log.args[0][0]['express.http.req.dev.count']).to.equal(1);
-					expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.count']).not.to.exist;
-					expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.time.mean']).not.to.exist;
-					expect(metrics.graphites[0].log.args[0][0]['express.dev.res.status.200.count']).to.equal(1);
-					expect(metrics.graphites[0].log.args[0][0]['express.dev.res.status.200.time.mean']).to.equal(0);
-					done();
+				clock.tick(100);
+				expect(metrics.graphites[0].log.args[0][0]['express.http.req.count']).to.equal(0);
+				expect(metrics.graphites[0].log.args[0][0]['express.http.req.dev.count']).to.equal(1);
+				expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.count']).not.to.exist;
+				expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.time.mean']).not.to.exist;
+				expect(metrics.graphites[0].log.args[0][0]['express.dev.res.status.200.count']).to.equal(1);
+				expect(metrics.graphites[0].log.args[0][0]['express.dev.res.status.200.time.mean']).to.equal(0);
+				done();
 			});
 	});
 
@@ -115,12 +115,12 @@ describe('Http metrics', function () {
 		request(app)
 			.get('/200?name=highway_61')
 			.end(() => {
-					clock.tick(100);
-					expect(metrics.graphites[0].log.args[0][0]['express.highway_61_GET.res.status.200.count']).to.equal(1);
-					expect(metrics.graphites[0].log.args[0][0]['express.highway_61_GET.res.status.200.time.mean']).to.exist;
-					expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.count']).to.not.exist;
-					expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.time.mean']).not.to.exist;
-					done();
+				clock.tick(100);
+				expect(metrics.graphites[0].log.args[0][0]['express.highway_61_GET.res.status.200.count']).to.equal(1);
+				expect(metrics.graphites[0].log.args[0][0]['express.highway_61_GET.res.status.200.time.mean']).to.exist;
+				expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.count']).to.not.exist;
+				expect(metrics.graphites[0].log.args[0][0]['express.default_route_GET.res.status.200.time.mean']).not.to.exist;
+				done();
 			});
 	});
 


### PR DESCRIPTION
We are seeing the alert on Heimdall for `Metrics: All services for retention registered in next-metrics (severity 3)`. Unfortunately it's difficult to the why it's failing unless it's failing at the point in time you're looking at it. 
At this point in time, it fails on `"checkOutput": "https://www.ft.com/__feedback-api/v1/survey services called but no metrics set up.",` - which makes sense because we added feedback functionality to `next-retention` in mid-August (https://github.com/Financial-Times/next-retention/pull/463). 