### PR TITLE
NOPS-346 added next-signup-api to services list

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -187,6 +187,7 @@ module.exports = {
 	'next-media-api-renditions': /^https?:\/\/next-media-api\.ft\.com\/renditions\/.*/,
 	'next-media-api-v1': /^https?:\/\/next-media-api\.ft\.com\/v1\/.*/,
 	'next-session-lambda': /https?:\/\/[^\.]+.execute-api\.eu-west-1\.amazonaws\.com/,
+	'next-signup-api': /^https:\/\/next-signup-api\.ft\.com\/.*/,
 	'next-syn-list': /^https?:\/\/www\.ft\.com\/syndication/,
 	'n-ui-assets': /ft-next-n-ui-prod(-us)?\.s3-website-(eu-west|us-east)-1\.amazonaws\.com\/__assets\/n-ui/,
 	'offer-api': /^https:\/\/(beta-)?api\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,


### PR DESCRIPTION
Next-signup-api is dead, long live next-signup-api! 

In next-retention, the docs suggest that any calls to next-signup-api are redirected to the relevant membership paths. When we implemented the new FOMO page in spring 2020, we left the old code, as is. We have a ticket to clean it up, but this is a larger project; meanwhile calls to next-signup-api are tripping Heimdall `Metrics: All services for retention registered in next-metrics (severity 3)` alert. This PR will silence the alert so that we have better visibility of **actual** problems. 