### PR TITLE
NOPS-354 Register Smartology in next-metrics Services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -231,6 +231,7 @@ module.exports = {
 	'sessions-api-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/sessions/,
 	'sharecode': /^https:\/\/sharecode\.ft\.com/,
 	'sharecount': /https?:\/\/sharecount\.webservices\.ft\.com\//,
+	'smartology': /^https?:\/\/c\.smartology\.co\/matches\/pcid\/ft\.com\%252Fcontent\%252F/,
 	'speedcurve-api': /^https:\/\/api\.speedcurve\.com/,
 	'splunk-hec': /^https:\/\/http-inputs-financialtimes\.splunkcloud\.com\/services\/collector\/event/,
 	'spoor-device-atlas-api': /^https?:\/\/spoor-deviceatlas-api\.ft\.com/,


### PR DESCRIPTION
## Meta
[NOPS-354][NOPS-354]

## Description
Calls to Smartology API need to be registered in `next-metrics` to avail of the monitoring tools that alert us if the API starts returning error responses.
See also https://monitoring-manager.ftops.tech/validate-healthcheck?url=https://ads-api.ft.com/__health

[NOPS-354]: https://financialtimes.atlassian.net/browse/NOPS-354