### PR TITLE
New domain name for routing voltdb-api requests through Fastly

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -141,7 +141,7 @@ module.exports = {
 	'ig-coronavirus-map': /^https?:\/\/ig.ft.com\/coronavirus-chart\/data-map-v2__world\.json/,
 	'ig-stream-content': /^https?:\/\/ft-ig-stream-content\.herokuapp\.com\//,
 	'internal-graphite': /^https?:\/\/graphite(v2)?-api\.ft\.com\//,
-	'ip-voltdb-api': /^https?:\/\/voltdb-api-(us|eu|eu-test).in.ft.com\//,
+	'ip-voltdb-api': /^https?:\/\/voltdb-api-(us|eu|eu-test|global).in.ft.com\//,
 	'kat': /^https?:\/\/kat\.ft\.com\/api\//,
 	'keen': /^https?:\/\/api\.keen\.io/,
 	'keen-proxy': /https:\/\/keen-proxy\.ft\.com\//,


### PR DESCRIPTION
New domain added: voltdb-api-global.in.ft.com.  This is the Fastly service which provides regional failover of the voltdb apis.