### PR TITLE
Remove ft-next-myft-api-test references

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -106,7 +106,6 @@ module.exports = {
 	'ft-next-in-article-barrier': /^https?:\/\/ft-next-article-eu\.herokuapp\.com\/in-article-barrier/,
 	'ft-next-markets-proxy-api': /^https?:\/\/markets-data-api-proxy\.ft\.com/,
 	'ft-next-myft-api': /https?\:\/\/ft-next-myft-api\.herokuapp\.com/,
-	'ft-next-myft-api-test': /https?\:\/\/ft-next-myft-api-test\.herokuapp\.com/,
 	'ft-next-myft-proxy': /^https:\/\/(www\.)?ft\.com\/__myft/,
 	'ft-next-topic-tracker-api': /^https:\/\/(www\.)?ft\.com\/__topic-tracker/,
 	'ft-next-myft-page': /https?\:\/\/ft-next-myft-page\.herokuapp\.com/,


### PR DESCRIPTION
No such Heroku app called `ft-next-myft-api-test` exists:
![Screenshot 2020-12-16 at 08 45 41](https://user-images.githubusercontent.com/10484515/102325540-2b9a6c80-3f7b-11eb-87f7-7595337f7c0e.png)

Visiting https://ft-next-myft-api-test.herokuapp.com results in **No such app**.

There are still a few bits of architecture for this app hanging around (as per below list), but my suspicion is that the Heroku app was removed but these other parts were left hanging.
- Hanging code references: https://github.com/search?q=user%3AFinancial-Times+ft-next-myft-api-test&type=Code
- Fastly service: https://manage.fastly.com/configure/services/62y0WLfLbWvsUnbcT3Aw92
- DNS entry: https://github.com/Financial-Times/dns/blob/master/config/main/ft.com.yaml#L5977-L5980