### PR TITLE
[ACQ-517] Add B2B students barrier service to metrics configuration

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -31,6 +31,7 @@ module.exports = {
 	'aws-elastic-v3-mget': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elastic(\.glb)?\.ft\.com)\/(v3_api_v2|content|embeds)\/(item\/)?_mget/,
 	'aws-elastic-v3-count': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elastic(\.glb)?\.ft\.com)\/(v3_api_v2|content|embeds)\/(item\/)?_count/,
 	'aws-elastic-v3-item': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elastic(\.glb)?\.ft\.com)\/(v3_api_v2|content|embeds)\/item/,
+	'b2b-students-barrier-eligibility-checkpoint': /^https:\/\/www\.ft\.com\/__b2b-student-check.*/,
 	'barriers-api': /^https?:\/\/subscribe\.ft\.com\/memb\/barrier/,
 	'barriers-api-direct': /^https?:\/\/barrier-app(-glb)?\.memb\.ft\.com\/memb\/barrier/,
 	'barriers-guru-individual-api': /^https?:\/\/barrier-guru\.ft\.com\/individual/,


### PR DESCRIPTION
Story: https://financialtimes.atlassian.net/browse/ACQ-517

Added `b2b-students-barrier-eligibility-checkpoint` matcher for URLs starting with `https://www.ft.com/__b2b-student-check`,
