### PR TITLE
Update ft-next-preflight-canary URL

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -116,7 +116,7 @@ module.exports = {
 	'ft-next-popular-api-concepts': /https:\/\/ft-next-popular-api\.herokuapp\.com\/concepts/,
 	'ft-next-popular-api-topics': /https:\/\/ft-next-popular-api\.herokuapp\.com\/topics/,
 	'ft-next-popular-api-videos': /https:\/\/ft-next-popular-api\.herokuapp\.com\/videos/,
-	'ft-next-preflight-canary': /^https?:\/\/ft-next-preflight-canary\.herokuapp\.com/,
+	'ft-next-preflight-canary': /^https?:\/\/ft-next-preflight-canary-eu\.herokuapp\.com/,
 	'ft-next-retention': /^https?:\/\/ft-next-retention-(eu|us)\.herokuapp\.com/,
 	'ft-next-service-registry': /https?:\/\/next-registry\.ft\.com/,
 	'ft-next-session-service': /^https?:\/\/session-next\.ft\.com/,


### PR DESCRIPTION
Updates value to reflect change of name of active Preflight Heroku Canary app.