### PR TITLE
Add  ft-next-graphics-api-proto to services.js

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -104,6 +104,7 @@ module.exports = {
 	'ft-next-es-interface-test-api': /^https?:\/\/test\.api\.ft\.com\/content\/.*/,
 	'ft-next-front-page': /^https?:\/\/ft-next-front-page-(eu|us)\.herokuapp\.com/,
 	'ft-next-graphics-page': /^https?:\/\/ft-next-graphics-page\.herokuapp\.com/,
+	'ft-next-graphics-api-proto': /^https?:\/\/ft-next-graphics-api-proto-(eu|eu2)\.herokuapp\.com/,
 	'ft-next-health': /^https?:\/\/ft-next-health-(eu|us)\.herokuapp\.com/,
 	'ft-next-in-article-barrier': /^https?:\/\/ft-next-article-eu\.herokuapp\.com\/in-article-barrier/,
 	'ft-next-markets-proxy-api': /^https?:\/\/markets-data-api-proxy\.ft\.com/,


### PR DESCRIPTION
This was missing. Not sure why this hasn't been picked up before. Is needed to display featured graphics on stream pages.