### PR TITLE
Added Fastly Realtime to register it's metrics

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -90,6 +90,7 @@ module.exports = {
 	'exec-appointments': /^https?:\/\/www\.exec-appointments\.com\/widget\/jobs\/;i=11/,
 	'fastly': /^https?:\/\/next\.ft\.com/,
 	'fastly-api': /^https?:\/\/api\.fastly\.com/,
+	'fastly-rt': /^https?:\/\/rt\.fastly\.com/,
 	'fow-api': /^https?:\/\/fow\.ft\.com\/api/,
 	'ft-kat-router': /^https?:\/\/ft-kat-router-(eu|us)\.herokuapp\.com/,
 	'ft-next-ammit-anubis-bayes': /^https?:\/\/ft-next-ammit-anubis\.herokuapp\.com\/bayes/,


### PR DESCRIPTION
MyFT API cache health check is using the Fastly Realtime service and needs this metric to be added ([see MyFT API]( https://github.com/Financial-Times/next-myft-api/blob/59421e4d4ded829772074cb12f1dbc6368f08c98/server/libs/health-checks/cache-hit.js)) file related.

(collaboration with @taraojo @fenglish)

### Meta

[Jira](https://financialtimes.atlassian.net/browse/CON-194)
