### PR TITLE
fix ontotext-popular service regex

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -197,7 +197,7 @@ module.exports = {
 	'offer-api': /^https:\/\/(beta-)?api\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'offer-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'ombudsman': /^https?:\/\/ombudsman\.in\.ft\.com/,
-	'ontotext-popular': /^https:\/\/api\.ft\.com\/recommended-reads-api\/recommend\/popular/,
+	'ontotext-popular': /^https?:\/\/api\.ft\.com\/recommended-reads-api\/recommend\/popular/,
 	'origami-image-service-v1': /^https?:\/\/www\.ft\.com\/__origami\/service\/image\/v1/,
 	'origami-image-service-v2': /^https?:\/\/www\.ft\.com\/__origami\/service\/image\/v2/,
 	'origami-navigation-menus': /^https:\/\/.*ft\.com\/__origami\/service\/navigation\/v2\/menus/,


### PR DESCRIPTION
Fix regex to match recommended-reads-api calls http and https requests (all other CAPI regex in this file do the same).


[Jira](https://financialtimes.atlassian.net/browse/CON-747)