### PR TITLE
CPP-474 - next-vault-sync API call not registered in next-metrics

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -59,6 +59,7 @@ module.exports = {
 	'capi-v2-people': /^https?:\/\/api\.ft\.com\/people\/[\w\-]+/,
 	'capi-v2-thing': /^https?:\/\/api\.ft\.com\/things\/[\w\-]+/,
 	'circleci-v2-project-api': /https:\/\/circleci\.com\/api\/v2\.?[0-9]?\/project\/[\w\-\/]+/,
+	'circleci-v1-project-api': /https:\/\/circleci\.com\/api\/v1\.?[0-9]?\/project\/[\w\-\/]+/,
 	'classification-api': /https:\/\/content-classification-api\.ft\.com\//,
 	'cloudinary': /^https?:\/\/res\.cloudinary\.com/,
 	'consent-api': /^https:\/\/(beta-)?api\.ft\.com\/consent/,


### PR DESCRIPTION
[Ticket CPP-474](https://financialtimes.atlassian.net/browse/CPP-474)

Ideally, we would want for `next-vault-sync` to only use v2 endpoints, but the CircleCI `/:project/settings` API endpoint has not been migrated by them to v2, so we need to keep using some v1 API endpoints in the mean time.