### PR TITLE
Update ig-coronavirus-map to new endpoint

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -142,7 +142,7 @@ module.exports = {
 	'heroku-api': /^https?:\/\/api\.heroku\.com/,
 	'hui': /^https?:\/\/api\.ft\.com\/hui\//,
 	'hui-content': /^https?:\/\/api\.ft\.com\/hui\/content/,
-	'ig-coronavirus-map': /^https?:\/\/ig.ft.com\/coronavirus-chart\/data-map-v2__world\.json/,
+	'ig-coronavirus-map': /^https?:\/\/ft-ig-content-prod.s3-eu-west-1.amazonaws.com\/v2\/Financial-Times\/data-journalism-covid-trajectories\/main\/world-map.json/,
 	'ig-coronavirus-vaccination': /^https?:\/\/ft-ig-content-prod.s3-eu-west-1.amazonaws.com\/v2\/Financial-Times\/data-journalism-covid-vaccinations\/main\/world_vax_totals.json/,
 	'ig-stream-content': /^https?:\/\/ft-ig-stream-content\.herokuapp\.com\//,
 	'internal-graphite': /^https?:\/\/graphite(v2)?-api\.ft\.com\//,


### PR DESCRIPTION
Relates to this change in next-article: https://github.com/Financial-Times/next-article/pull/4205/files

Changes url `https://ig.ft.com/coronavirus-chart/data-map-v2__world.json` to `https://ft-ig-content-prod.s3-eu-west-1.amazonaws.com/v2/Financial-Times/data-journalism-covid-trajectories/main/world-map.json`