### PR TITLE
NOPS-741 Add vouchers service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -299,6 +299,7 @@ module.exports = {
 	'user-svc-test': /^https:\/\/(beta-)?api-t\.ft\.com\/users/,
 	'video': /https?:\/\/next-video\.ft\.com/,
 	'video-whakataki-lambda-things': /^https:\/\/thing-videotest\.ft\.com\/things/,
+	'vouchers': /https:\/\/api\.ft\.com\/print\/v1\/vouchers,
 	'www-article': /https:\/\/www\.ft\.com\/content\/.+/,
 	'zuora-system-status': /trust\.zuora\.com/, // used in next-signup healthchecks
 	// white-label consent & cookie metrics for Specialist Titles


### PR DESCRIPTION
Adds the voucher service that is used and previously not registered:
`https://api.ft.com/print/v1/vouchers`