### PR TITLE
Add the old live blog assets services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -213,6 +213,7 @@ module.exports = {
 	'n-ui-assets': /ft-next-n-ui-prod(-us)?\.s3-website-(eu-west|us-east)-1\.amazonaws\.com\/__assets\/n-ui/,
 	'offer-api': /^https:\/\/(beta-)?api\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'offer-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
+	'old-live-blog-posts': /^https?:\/\/e9b042pk7f\.execute-api\.eu-west-1\.amazonaws\.com\/prod\/posts-[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\.json/,
 	'ombudsman': /^https?:\/\/ombudsman\.in\.ft\.com/,
 	'ontotext-popular': /^https?:\/\/api\.ft\.com\/recommended-reads-api\/recommend\/popular/,
 	'origami-image-service-v1': /^https?:\/\/www\.ft\.com\/__origami\/service\/image\/v1/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -213,6 +213,7 @@ module.exports = {
 	'n-ui-assets': /ft-next-n-ui-prod(-us)?\.s3-website-(eu-west|us-east)-1\.amazonaws\.com\/__assets\/n-ui/,
 	'offer-api': /^https:\/\/(beta-)?api\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'offer-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
+	'old-live-blog-images': /^https?:\/\/e9b042pk7f\.execute-api\.eu-west-1\.amazonaws\.com\/prod\/images/,
 	'old-live-blog-posts': /^https?:\/\/e9b042pk7f\.execute-api\.eu-west-1\.amazonaws\.com\/prod\/posts-[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\.json/,
 	'ombudsman': /^https?:\/\/ombudsman\.in\.ft\.com/,
 	'ontotext-popular': /^https?:\/\/api\.ft\.com\/recommended-reads-api\/recommend\/popular/,


### PR DESCRIPTION
These live blogs used to be powered by wordpress but we aim to decommission wordpress so we have moved the data into an S3 bucket.

I have added services for returning the posts data and also the images separately as it will help us monitor this change.