### PR TITLE
NOPS-818: Allow embeds in ES search url

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -28,7 +28,7 @@ module.exports = {
 	'alphaville': /^https?:\/\/ftalphaville\.ft\.com/,
 	'anon-email-list-api': /https:\/\/anon-email-lists-eu-(prod|test)\.herokuapp\.com/,
 	'asana': /^https:\/\/app\.asana\.com\//,
-	'aws-elastic-v7-search': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elasticsearch-v7\.gslb\.ft\.com)\/content\/_search/,
+	'aws-elastic-v7-search': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elasticsearch-v7\.gslb\.ft\.com)\/(content|embeds)\/_search/,
 	'aws-elastic-v7-mget': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elasticsearch-v7\.gslb\.ft\.com)\/content\/_mget/,
 	'aws-elastic-v7-count': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elasticsearch-v7\.gslb\.ft\.com)\/content\/_count/,
 	'aws-elastic-v7-doc': /^https?:\/\/([\w\-]+\.[\w\-]+\.es\.amazonaws\.com|next-elasticsearch-v7\.gslb\.ft\.com)\/content\/_doc/,


### PR DESCRIPTION
next-graphics-page has a [slightly different search url](https://github.com/Financial-Times/next-graphics-page/blob/master/server/checks/main.js#L15) so the 'all services registered' healthcheck goes off because it is not included in this list. 

This PR extends the regex to allow for both search urls.