### PR TITLE
fix: fix regex for capi-v2-concepts in services.js

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -52,7 +52,7 @@ module.exports = {
 	'capi-v2-brands': /^https?:\/\/api\.ft\.com\/brands\/[\w\-]+/,
 	'capi-v2-concordances': /^https?:\/\/api\.ft\.com\/concordances\?/,
 	'capi-v2-content-by-concept': /^https?:\/\/api\.ft\.com\/content\?isAnnotatedBy=http:\/\/api\.ft\.com\/things\/[\w\-]+/,
-	'capi-v2-concepts': /^https?:\/\/api\.ft\.com\/concepts\/[\w\-]+/,
+	'capi-v2-concepts': /^https?:\/\/api\.ft\.com\/concepts\/?[\w\-]*/,
 	'capi-v2-enriched-article': /^https?:\/\/api\.ft\.com\/enrichedcontent\/[\w\-]+/,
 	'capi-v2-internal': /^https?:\/\/api\.ft\.com\/internalcontent\/[\w\-]+/,
 	'capi-v2-lists': /^https?:\/\/api\.ft\.com\/lists/,


### PR DESCRIPTION
Replace:
```js
/^https?:\/\/api\.ft\.com\/concepts\/[\w\-]+/
```
with:
```js
/^https?:\/\/api\.ft\.com\/concepts\/?[\w\-]{0,}/
```
as the former does not match `https://api.ft.com/concepts` with out anything additional on the path