### PR TITLE
DATA-4399 Register the new secured device-atlas url to next-metrics services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -265,7 +265,7 @@ module.exports = {
 	'smartology': /^https?:\/\/c\.smartology\.co\/matches\/pcid\/ft\.com\%252Fcontent\%252F/,
 	'speedcurve-api': /^https:\/\/api\.speedcurve\.com/,
 	'splunk-hec': /^https:\/\/http-inputs-financialtimes\.splunkcloud\.com\/services\/collector\/event/,
-	'spoor-device-atlas-api': /^https?:\/\/spoor-deviceatlas-api\.ft\.com/,
+	'spoor-device-atlas-api': /^https:\/\/(spoor-deviceatlas-api\.ft\.com|api\.ft\.com\/spoor-device-atlas)/,
 	'spoor-ingest': /^https?:\/\/spoor-api\.ft\.com\/ingest/,
 	'spoor-voltdb-api': /^https?:\/\/spoor-voltdb\.in\.ft\.com\:8080\/api\/1\.0\//,
 	'spoor-website-type': /^https:\/\/spoor-website-api\.ft\.com/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -265,7 +265,7 @@ module.exports = {
 	'smartology': /^https?:\/\/c\.smartology\.co\/matches\/pcid\/ft\.com\%252Fcontent\%252F/,
 	'speedcurve-api': /^https:\/\/api\.speedcurve\.com/,
 	'splunk-hec': /^https:\/\/http-inputs-financialtimes\.splunkcloud\.com\/services\/collector\/event/,
-	'spoor-device-atlas-api': /^https:\/\/(spoor-deviceatlas-api\.ft\.com|api\.ft\.com\/spoor-device-atlas)/,
+	'spoor-device-atlas-api': /^https?:\/\/(spoor-deviceatlas-api\.ft\.com|api\.ft\.com\/spoor-device-atlas)/,
 	'spoor-ingest': /^https?:\/\/spoor-api\.ft\.com\/ingest/,
 	'spoor-voltdb-api': /^https?:\/\/spoor-voltdb\.in\.ft\.com\:8080\/api\/1\.0\//,
 	'spoor-website-type': /^https:\/\/spoor-website-api\.ft\.com/,


### PR DESCRIPTION
### Description:
Add the new secured DeviceAtlas URL (`https://api.ft.com/spoor-device-atlas`) to the metrics

> We are migrating our DeviceAtlas service to another domain but we need to still support the old one so we updated the original regex to match both of them.

### Jira ticket:
[DATA-4399](https://financialtimes.atlassian.net/browse/DATA-4399)