### PR TITLE
Add graphics-api-proto service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -108,6 +108,7 @@ module.exports = {
 	'ft-next-es-interface-us': /^https?:\/\/ft-next-es-interface-us\.herokuapp\.com/,
 	'ft-next-es-interface-test-api': /^https?:\/\/test\.api\.ft\.com\/content\/.*/,
 	'ft-next-front-page': /^https?:\/\/ft-next-front-page-(eu|us)\.herokuapp\.com/,
+	'ft-next-graphics-api-proto': /^https?:\/\/ft-next-graphics-api-proto-(eu|eu2)\.herokuapp\.com/,
 	'ft-next-health': /^https?:\/\/ft-next-health-(eu|us)\.herokuapp\.com/,
 	'ft-next-in-article-barrier': /^https?:\/\/ft-next-article-eu\.herokuapp\.com\/in-article-barrier/,
 	'ft-next-markets-proxy-api': /^https?:\/\/markets-data-api-proxy\.ft\.com/,


### PR DESCRIPTION
This was removed as we weren't sure what was still using it, it turns out the stream page was using it still and so we are adding it back in