### PR TITLE
Don't force dependents to be using npm 7

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,13 +32,12 @@
     "npm": "7.x"
   },
   "scripts": {
-    "prepare": "npx snyk protect || npx snyk protect -d || true",
-    "preinstall": "npm_config_yes=true npx check-engine"
+    "prepare": "npx snyk protect || npx snyk protect -d || true"
   },
   "husky": {
     "hooks": {
       "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
-      "pre-commit": "node_modules/.bin/secret-squirrel",
+      "pre-commit": "node_modules/.bin/secret-squirrel && npm_config_yes=true npx check-engine",
       "pre-push": "make verify -j3"
     }
   },


### PR DESCRIPTION
The `check-engine` script we were using to enforce npm 7 usage when developing locally was also being run when the package was installed by other consumers, causing the installation to fail if they were using an npm version other than 7. This is an unnecessarily restrictive requirement which would mean the npm 7 update was a breaking change -- not our intention.

Instead, run the version check in a git hook so that it is only enforced development, as was originally intended. Unfortunately, the version of husky we are using breaks the `PATH` in a way that causes a false negative when the default version of npm installed by Volta is not npm 7, but we need to get this unblocked now so we don't need to make a major release and we can make another patch fixing this bug later.