### PR TITLE
Put npm 7 check back into preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,13 @@
     "npm": "7.x"
   },
   "scripts": {
-    "prepare": "npx snyk protect || npx snyk protect -d || true"
+    "prepare": "npx snyk protect || npx snyk protect -d || true",
+    "preinstall": "[[ \"$INIT_CWD\" != \"$PWD\" ]] || npm_config_yes=true npx check-engine"
   },
   "husky": {
     "hooks": {
       "commit-msg": "node_modules/.bin/secret-squirrel-commitmsg",
-      "pre-commit": "node_modules/.bin/secret-squirrel && npm_config_yes=true npx check-engine",
+      "pre-commit": "node_modules/.bin/secret-squirrel",
       "pre-push": "make verify -j3"
     }
   },


### PR DESCRIPTION
The hack added in #431 to stop installations failing when using an older version of npm has now been refined to be compatible with Volta and no longer a hack.