### PR TITLE
CPP-661 remove ammit-anubis references

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -98,8 +98,6 @@ module.exports = {
 	'fastly-rt': /^https?:\/\/rt\.fastly\.com/,
 	'fow-api': /^https?:\/\/fow\.ft\.com\/api/,
 	'ft-kat-router': /^https?:\/\/ft-kat-router-(eu|us)\.herokuapp\.com/,
-	'ft-next-ammit-anubis-bayes': /^https?:\/\/ft-next-ammit-anubis\.herokuapp\.com\/bayes/,
-	'ft-next-ammit-anubis-config': /^https?:\/\/ft-next-ammit-anubis\.herokuapp\.com\/config/,
 	'ft-next-comments-api': /^https?:\/\/comments-api\.ft\.com/,
 	'ft-next-api-user-prefs-v002': /^https?:\/\/ft-next-api-user-prefs-v002\.herokuapp\.com/,
 	'ft-next-article-preview': /^https?:\/\/ft-next-article-(eu|us)\.herokuapp\.com\/preview/,


### PR DESCRIPTION
these pertain to the old old `ammit-anubis` service, which has been decommissioned since 2019, not `next-anubis-config-api` and `next-anubis-scheduled-jobs` that replaced it, lol