### PR TITLE
Disable noisy log on every socket opening/closing

### DIFF
--- a/lib/graphite/client.js
+++ b/lib/graphite/client.js
@@ -39,15 +39,10 @@ Graphite.prototype.log = function (metrics) {
 	const { port, host } = this.destination;
 
 	const socket = net.createConnection(port, host, function () {
-		logger.debug({ event: 'NEXT_METRICS_GRAPHITE_CLIENT_CONNECTED', host });
 		_.forEach(dataChunks, (chunk) => {
 			socket.write(chunk.join('\n') + '\n'); // trailing \n to ensure the last metric is registered
 		});
 		socket.end();
-	});
-
-	socket.on('end', () => {
-		logger.debug({ event: 'NEXT_METRICS_GRAPHITE_CLIENT_DISCONNECTED', host });
 	});
 
 	socket.on('error', (err) => {


### PR DESCRIPTION
A suggested change removing this noisy log. It is constantly loggin on opening and closing a socket but not sure if anyone benefits from it. Open for discussion! 👍🏻 