### PR TITLE
Make sure lodash is invulnerable version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "dependencies": {
         "@financial-times/n-logger": "^5.5.6",
-        "lodash": "^4.17.10",
+        "lodash": "^4.17.21",
         "metrics": "^0.1.8"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "dependencies": {
     "@financial-times/n-logger": "^5.5.6",
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.21",
     "metrics": "^0.1.8"
   },
   "devDependencies": {


### PR DESCRIPTION
next-metrics is listed as one of the providers for vulnerable `lodash` version to next-api.
However according to `package-lock.json`, next-metrics is using the latest(invulnerable) version already. 
I'm not sure the reason why snyk alerts this app. However I'm going to change the `package.json` and I would like to see whether snyk picks up the version correctly or not.

![Screenshot 2022-02-02 at 15 07 13](https://user-images.githubusercontent.com/21194161/152180480-6520419f-7fd3-42cf-9a24-a129adba16f8.png)
([link](
https://app.snyk.io/org/customer-products/project/52549f05-14d7-4b56-bba7-3ca83742fa57#issue-SNYK-JS-LODASH-590103))