### PR TITLE
ACQ-1448: add salesforce auth test url

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -250,6 +250,7 @@ module.exports = {
 	'rj-capi-mock': /^https:\/\/s3-eu-west-1\.amazonaws\.com\/rj-xcapi-mock\/production\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}(\.json)?/,
 	'rj-up': /^https?:\/\/rj-up\.ft\.com/,
 	'salesforce-auth-api': /^https:\/\/login\.salesforce\.com\/services\/oauth2\/token/,
+	'salesforce-auth-api-test': /^https:\/\/test\.salesforce\.com\/services\/oauth2\/token/,
 	'salesforce-contract-api': /^https:\/\/financialtimes\.my\.salesforce\.com\/services\/apexrest\/SCRMKATContract\/.*/,
 	'sapi': /^https?:\/\/api\.ft\.com\/content\/search\/v1/,
 	'sapi-2': /^https?:\/\/search-services\.ft\.com\/search-services\/search/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "next-metrics",
       "version": "0.0.0",
       "hasInstallScript": true,
       "dependencies": {


### PR DESCRIPTION
Fixes the following alert:
heimdall alert for the following [FT.com](http://ft.com/) Subscribe Page - Metrics: All services for subscribe registered in next-metrics - [https://test.salesforce.com/services/oauth2/token> services called but no metrics set up. can you help/advise <https://heimdall.ftops.tech/system?returnTo=%2Foperations&code=next-subscribe#monitored-checks-list>  and   <https://ft-next-subscribe-eu.herokuapp.com/__health](https://test.salesforce.com/services/oauth2/token%3E%20services%20called%20but%20no%20metrics%20set%20up.%20can%20you%20help/advise%20%3Chttps://heimdall.ftops.tech/system?returnTo=%2Foperations&code=next-subscribe#monitored-checks-list%3E%20%20and%20%20%20%3Chttps://ft-next-subscribe-eu.herokuapp.com/__health)

https://financialtimes.atlassian.net/browse/ACQ-1448

