### PR TITLE
Update endpoint for barrier-guru api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -37,7 +37,7 @@ module.exports = {
 	'barriers-api-direct': /^https?:\/\/barrier-app(-glb)?\.memb\.ft\.com\/memb\/barrier/,
 	'barriers-guru-individual-api': /^https?:\/\/barrier-guru\.ft\.com\/individual/,
 	'barriers-guru-corporate-api': /^https?:\/\/barrier-guru\.ft\.com\/corporate/,
-	'barrier-guru-api': /^https?:\/\/barrier-guru\.ft\.com\/barrier/,
+	'barrier-guru-api': /^https?:\/\/barrier-guru\.ft\.com\/preflight/,
 	'bertha': /^https?:\/\/bertha\.ig\.ft\.com/,
 	'bitly': /^https:\/\/api-ssl\.bitly\.com\/v[34]\/shorten/,
 	'bizzabo-events': /^https:\/\/api\.bizzabo\.com\/api\/events/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -38,6 +38,7 @@ module.exports = {
 	'barriers-guru-individual-api': /^https?:\/\/barrier-guru\.ft\.com\/individual/,
 	'barriers-guru-corporate-api': /^https?:\/\/barrier-guru\.ft\.com\/corporate/,
 	'barrier-guru-api': /^https?:\/\/barrier-guru\.ft\.com\/preflight/,
+	'barrier-guru-api-product': /^https?:\/\/barrier-guru\.ft\.com\/barrier/,
 	'bertha': /^https?:\/\/bertha\.ig\.ft\.com/,
 	'bitly': /^https:\/\/api-ssl\.bitly\.com\/v[34]\/shorten/,
 	'bizzabo-events': /^https:\/\/api\.bizzabo\.com\/api\/events/,


### PR DESCRIPTION
Fixed the alerts in https://heimdall.ftops.tech/system?code=next-preflight

Alerts are happening as we have recently updated the next-preflight to use a new API endpoint. https://github.com/Financial-Times/next-preflight/pull/615