### PR TITLE
added insights gateway aggregation point

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -153,6 +153,7 @@ module.exports = {
 	'invoice-api' : /^https:\/\/api\.ft\.com\/invoice\/invoices.*/,
 	'invoice-api-test' : /^https:\/\/api-t\.ft\.com\/invoice\/invoices.*/,
 	'insights-api': /^https:\/\/insights-api\.ft\.com\/v1\/aggregations.*/,
+	'insights-api-gateway': /^https:\/\/api.ft.com\/snr\/v1\/insights\/aggregations\/[\w\-]+/,
 	'ip-voltdb-api': /^https?:\/\/voltdb-api-(us|eu|eu-test|global).in.ft.com\//,
 	'kat': /^https?:\/\/kat\.ft\.com\/api\//,
 	'keen': /^https?:\/\/api\.keen\.io/,


### PR DESCRIPTION
`next-retention` has been alerting over the weekend because we're now accessing the Insights endpoint via the gateway (rather than the old URL). This PR adds the regex for the new endpoint. 