### PR TITLE
Add service for www-well-known

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -321,6 +321,7 @@ module.exports = {
 	'video-whakataki-lambda-things': /^https:\/\/thing-videotest\.ft\.com\/things/,
 	'vouchers': /https:\/\/api\.ft\.com\/print\/v1\/vouchers/,
 	'www-article': /https:\/\/www\.ft\.com\/content\/.+/,
+	'www-well-known': /https:\/\/www\.ft\.com\/.well-known\/.+/,
 	'zuora-system-status': /trust\.zuora\.com/, // used in next-signup healthchecks
 	// white-label consent & cookie metrics for Specialist Titles
 	// we need them here to silence the "We don't have any visibility with unregistered services" healthchecks


### PR DESCRIPTION
This service should track everything in the .well-known directory of ft.com which includes https://www.ft.com/.well-known/security.txt (which we monitor programatically).