### PR TITLE
[FTDCS-169] Add www.ft.com/__verify-ft-next-backend-keys

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -324,6 +324,7 @@ module.exports = {
 	'vouchers': /https:\/\/api\.ft\.com\/print\/v1\/vouchers/,
 	'www-article': /https:\/\/www\.ft\.com\/content\/.+/,
 	'www-well-known': /https:\/\/www\.ft\.com\/.well-known\/.+/,
+	'www-verify-backend-key': /https:\/\/www\.ft\.com\/__verify-ft-next-backend-keys/,
 	'zuora-system-status': /trust\.zuora\.com/, // used in next-signup healthchecks
 	// white-label consent & cookie metrics for Specialist Titles
 	// we need them here to silence the "We don't have any visibility with unregistered services" healthchecks


### PR DESCRIPTION
This is alerting because next-health is now requesting this endpoint but we don't store metrics for it.

I don't know why this wasn't causing alerts when next-vault-sync was requesting it.