### PR TITLE
Instrument other fetch instances not only global.fetch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
             .circleci/shared-helpers
       - *restore_npm_cache
       - node/install-npm:
-          version: "7"
+          version: "7.20.2"
       - run:
           name: Install project dependencies
           command: make install

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ classes that might help you out:
 ```javascript
 // Create your own instance of Metrics
 const { Metrics } = require("next-metrics");
-
+const fetch = require('node-fetch');
 const metrics = new Metrics();
 
 metrics.init({
@@ -102,6 +102,8 @@ metrics.init({
   useDefaultAggregators: false,
   flushEvery: false,
   forceGraphiteLogging: true,
+  fetchInstance : fetch, // fetch instance to make request, if we do not pass an instance isomorphic-fetch would be the default fetch instance and will be assigned to global.fetch
+  overrideGlobalFetch: true, //  use to indicate if our fetchInstance should override global.fetch, true by default .
 });
 
 metrics.count("some_filename.size", 2454589);
@@ -145,7 +147,7 @@ argument specifies what type of object it is.
 
 ## Services
 
-`next-metrics` logs details of `fetch` requests your app makes, by instrumenting [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch).
+`next-metrics` logs details of `fetch` requests your app makes, by instrumenting [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch). or the instance that you pass on the option fetchInstance in method init. If we set the option overrideGlobalFetch to false and a fetchInstance , global.fetch wont be override or assigned with our instrumented instance.
 
 So that these metrics are properly grouped and labelled in Graphite, you need to register any HTTP endpoint you call in [`services.js`](https://github.com/Financial-Times/next-metrics/blob/HEAD/lib/metrics/services.js). Any endpoint you call that _isn't_ registered will cause [a default `n-express` healthcheck](https://github.com/Financial-Times/n-express/blob/HEAD/src/lib/unregistered-services-healthCheck.js) to fail.
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -44,6 +44,10 @@ Metrics.prototype.init = function (opts) {
 
 	this.opts = opts;
 
+	if(this.opts.fetchInstance){
+		this.fetch = new Proxies.Fetch({fetchInstance : this.opts.fetchInstance});
+	}
+
 	let hasValidConfiguration = true;
 
 	const FT_GRAPHITE_APP_UUID = process.env.FT_GRAPHITE_APP_UUID;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -44,7 +44,7 @@ Metrics.prototype.init = function (opts) {
 
 	this.opts = opts;
 
-	this.fetch = new Proxies.Fetch({fetchInstance : this.opts.fetchInstance , instrumentGlobalFetch : this.opts.instrumentGlobalFetch});
+	this.fetch = new Proxies.Fetch({fetchInstance : this.opts.fetchInstance , overrideGlobalFetch : this.opts.overrideGlobalFetch});
 
 
 	let hasValidConfiguration = true;

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -24,7 +24,7 @@ const logger = require('@financial-times/n-logger').default;
 
 const Metrics = function () {
 
-	this.fetch = new Proxies.Fetch();
+	this.fetch;
 
 	this.opts = {};
 	this.graphites = [];
@@ -44,9 +44,8 @@ Metrics.prototype.init = function (opts) {
 
 	this.opts = opts;
 
-	if(this.opts.fetchInstance){
-		this.fetch = new Proxies.Fetch({fetchInstance : this.opts.fetchInstance});
-	}
+	this.fetch = new Proxies.Fetch({fetchInstance : this.opts.fetchInstance , instrumentGlobalFetch : this.opts.instrumentGlobalFetch});
+
 
 	let hasValidConfiguration = true;
 

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -35,7 +35,7 @@ module.exports = class {
 			throw new Error('next-metrics: You need to `require(\'isomorphic-fetch\');` or pass a fetchInstance as an option before instrumenting it');
 		}
 
-		const useGlobalFetch = this.deps.instrumentGlobalFetch !== false;
+		const useGlobalFetch = this.deps.overrideGlobalFetch !== false;
 		const fetchInstance = this.deps.fetchInstance || global.fetch;
 
 		if (fetchInstance._instrumented) {
@@ -95,7 +95,7 @@ module.exports = class {
 		};
 
 		fetchInstrumented._instrumented = true;
-
+		fetchInstrumented._fromFetchInstance = !!this.deps.fetchInstance;
 		fetchInstrumented.restore = () => {
 			fetchInstrumented = fetchInstance;
 			if(useGlobalFetch)

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -35,7 +35,7 @@ module.exports = class {
 			throw new Error('next-metrics: You need to `require(\'isomorphic-fetch\');` or pass a fetchInstance as an option before instrumenting it');
 		}
 
-		const useGlobalFetch = !this.deps.fetchInstance;
+		const useGlobalFetch = this.deps.instrumentGlobalFetch !== false;
 		const fetchInstance = this.deps.fetchInstance || global.fetch;
 
 		if (fetchInstance._instrumented) {
@@ -98,9 +98,9 @@ module.exports = class {
 
 		fetchInstrumented.restore = () => {
 			fetchInstrumented = fetchInstance;
-			if(useGlobalFetch){
+			if(useGlobalFetch)
 				global.fetch = fetchInstance;
-			}
+
 		};
 
 		if(useGlobalFetch)

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -31,21 +31,26 @@ module.exports = class {
 	}
 
 	instrument ({ metricsInstance, onUninstrumented = () => {}} = {}) {
-		if (!global.fetch) {
-			throw new Error('next-metrics: You need to `require(\'isomorphic-fetch\');` before instrumenting it');
+		if (!global.fetch && !this.deps.fetchInstance) {
+			throw new Error('next-metrics: You need to `require(\'isomorphic-fetch\');` or pass a fetchInstance as an option before instrumenting it');
 		}
-		if (global.fetch._instrumented) {
+
+		const useGlobalFetch = !this.deps.fetchInstance;
+		const fetchInstance = this.deps.fetchInstance || global.fetch;
+
+		if (fetchInstance._instrumented) {
 			return logger.warn({ event: 'NEXT_METRICS_FETCH_ALREADY_INSTRUMENTED', message: 'You can only instrument fetch once. Remember, if you\'re using next-express metrics, most fetch calls are setup automatically' });
 		}
+
+
 
 		// FIXME: dynamic require so it doesn't get in a circular loop
 		(metricsInstance || require('../../index'))
 			.registerAggregator(this.reporter.bind(this));
 
-		const _fetch = global.fetch;
 		const that = this; // not using bind as don't want to muck around with fetch's scope
 
-		global.fetch = function (url) {
+		let fetchInstrumented = function (url) {
 			const service = Object.keys(that.deps.services)
 				.find(serviceName => that.deps.services[serviceName].test(url));
 
@@ -56,7 +61,7 @@ module.exports = class {
 				const start = Date.now();
 				let end;
 
-				const response = _fetch.apply(this, arguments);
+				const response = fetchInstance.apply(this, arguments);
 				response.then(() => {
 					end = Date.now();
 				}).catch(() => {}); // empty catch as exceptions are handled in other promise chains
@@ -85,14 +90,23 @@ module.exports = class {
 				return response;
 			} else {
 				onUninstrumented.apply(this, arguments);
-				return _fetch.apply(this, arguments);
+				return fetchInstance.apply(this, arguments);
 			}
 		};
 
-		global.fetch._instrumented = true;
-		global.fetch.restore = () => {
-			global.fetch = _fetch;
+		fetchInstrumented._instrumented = true;
+
+		fetchInstrumented.restore = () => {
+			fetchInstrumented = fetchInstance;
+			if(useGlobalFetch){
+				global.fetch = fetchInstance;
+			}
 		};
+
+		if(useGlobalFetch)
+			global.fetch = fetchInstrumented;
+
+		return fetchInstrumented;
 	}
 
 	getMetricReport (service, key = '') {

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -255,7 +255,7 @@ describe('lib/metrics', () => {
 
 				instance.init({...options,fetchInstance : fetchInstanceStub} );
 			});
-			it('fetch deps should fave option fetchInstance', () => {
+			it('fetch deps should have option fetchInstance', () => {
 				assert.equal(instance.fetch.deps.fetchInstance,fetchInstanceStub);
 			});
 		});

--- a/test/unit/lib/metrics.spec.js
+++ b/test/unit/lib/metrics.spec.js
@@ -246,6 +246,20 @@ describe('lib/metrics', () => {
 
 		});
 
+		describe('when fetchInstance option is passed in constructor', () => {
+			const fetchInstanceStub = sinon.stub()
+				.resolves({
+					status: 200
+				});
+			beforeEach(() => {
+
+				instance.init({...options,fetchInstance : fetchInstanceStub} );
+			});
+			it('fetch deps should fave option fetchInstance', () => {
+				assert.equal(instance.fetch.deps.fetchInstance,fetchInstanceStub);
+			});
+		});
+
 	});
 
 });

--- a/test/unit/lib/metrics/fetch.spec.js
+++ b/test/unit/lib/metrics/fetch.spec.js
@@ -219,6 +219,7 @@ describe('Fetch', () => {
 		const fetch = new Fetch({fetchInstance : fetchInstanceStub});
 		const fetchInstrumentedInstance = fetch.instrument();
 		fetchInstrumentedInstance.should.equal(global.fetch);
+		expect(global.fetch._fromFetchInstance).to.equal(true);
 		fetchInstrumentedInstance._instrumented.should.be.true;
 
 	});
@@ -230,9 +231,10 @@ describe('Fetch', () => {
 
 		global.fetch = null;
 
-		const fetch = new Fetch({fetchInstance : fetchInstanceStub , instrumentGlobalFetch : false});
+		const fetch = new Fetch({fetchInstance : fetchInstanceStub , overrideGlobalFetch : false});
 		const fetchInstrumentedInstance = fetch.instrument();
 		fetchInstrumentedInstance.should.not.equal(global.fetch);
+		expect(fetchInstrumentedInstance._fromFetchInstance).to.equal(true);
 		fetchInstrumentedInstance._instrumented.should.be.true;
 	});
 });

--- a/test/unit/lib/metrics/fetch.spec.js
+++ b/test/unit/lib/metrics/fetch.spec.js
@@ -6,7 +6,7 @@ const Fetch = require('../../../../lib/metrics/fetch');
 
 chai.use(sinonChai);
 const should = chai.should();
-
+const expect = chai.expect;
 
 describe('Fetch', () => {
 
@@ -36,7 +36,12 @@ describe('Fetch', () => {
 	it('should throw error if instrumenting when there’s no `global.fetch`', () => {
 		global.fetch = undefined;
 		const fetch = new Fetch();
-		fetch.instrument.should.throw('You need to `require(\'isomorphic-fetch\');` before instrumenting it');
+		try{
+			fetch.instrument();
+		}
+		catch(error){
+			expect(error.message).to.equal('next-metrics: You need to `require(\'isomorphic-fetch\');` or pass a fetchInstance as an option before instrumenting it');
+		}
 	});
 
 	it('should be able to restore', () => {
@@ -202,5 +207,21 @@ describe('Fetch', () => {
 				done();
 			}, 10);
 		}, 10);
+	});
+
+	it('should be able to use fetchInstance instead global.fetch', () => {
+		const fetchInstanceStub = sinon.stub()
+			.resolves({
+				status: 200
+			});
+
+		global.fetch.should.equal(fetchStub);
+
+		const fetch = new Fetch({fetchInstance : fetchInstanceStub});
+		const fetchInstrumentedInstance = fetch.instrument();
+		fetchInstrumentedInstance.should.not.equal(global.fetch);
+		fetchInstrumentedInstance._instrumented.should.be.true;
+		expect(global.fetch._instrumented).to.be.undefined;
+
 	});
 });

--- a/test/unit/lib/metrics/fetch.spec.js
+++ b/test/unit/lib/metrics/fetch.spec.js
@@ -28,7 +28,6 @@ describe('Fetch', () => {
 	it('should be able to instrument', () => {
 		const fetch = new Fetch();
 		fetch.instrument();
-
 		global.fetch._instrumented.should.be.true;
 		global.fetch.should.not.equal(fetchStub);
 	});
@@ -209,7 +208,7 @@ describe('Fetch', () => {
 		}, 10);
 	});
 
-	it('should be able to use fetchInstance instead global.fetch', () => {
+	it('should be able to use fetchInstance and assign to global.fetch', () => {
 		const fetchInstanceStub = sinon.stub()
 			.resolves({
 				status: 200
@@ -219,9 +218,21 @@ describe('Fetch', () => {
 
 		const fetch = new Fetch({fetchInstance : fetchInstanceStub});
 		const fetchInstrumentedInstance = fetch.instrument();
+		fetchInstrumentedInstance.should.equal(global.fetch);
+		fetchInstrumentedInstance._instrumented.should.be.true;
+
+	});
+	it('should be able to use fetchInstance without assign to global.fetch', () => {
+		const fetchInstanceStub = sinon.stub()
+			.resolves({
+				status: 200
+			});
+
+		global.fetch = null;
+
+		const fetch = new Fetch({fetchInstance : fetchInstanceStub , instrumentGlobalFetch : false});
+		const fetchInstrumentedInstance = fetch.instrument();
 		fetchInstrumentedInstance.should.not.equal(global.fetch);
 		fetchInstrumentedInstance._instrumented.should.be.true;
-		expect(global.fetch._instrumented).to.be.undefined;
-
 	});
 });


### PR DESCRIPTION
Why ? 
Right now this library only instruments global.fetch variable that is usually created by isomorphicfetch . But in some apps it is been used node-fetch due to it has mor capabilities. 

So I create this PR in order this other apps could instrument node-fetch or other instance. This changes keeps retrocompatibility.

I Added two optional parameters in init method of metrics :
 - "fetchInstance" in this parameter  we can pass an instance that we want to instrument. For example we can pass a node-fetch function 
 - "overrideGlobalFetch"  this parameter is a boolean . By default is true. What it does is set global.fetch and instrument it.
Example:
```
const fetch = require('node-fetch')
const metrics = require('next-metrics')
const fetchInstrumented = metrics.init({fetchInstance : fetch });
``` 

In this example we are instrumenting fetch from node-fetch and also assign it to global.fetch. if we don't want to assign to global.fetch just pass instrumentGlobalFetch parameter to false.
I have done these in order to be able to keep compatibility with older versions and also give a way to easily change from isomorphicfetch to node-fetch

