### PR TITLE
fix(services): adds https://api-t.ft.com/set-default-payment url to s…

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -269,6 +269,7 @@ module.exports = {
 	'sessions-api-ft': /^https:\/\/(beta-)?api\.ft\.com\/sessions/,
 	'sessions-api-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/sessions/,
 	'set-default-payment': /^https:\/\/api\.ft\.com\/set-default-payment\/.*/,
+	'set-default-payment-test': /^https:\/\/api-t\.ft\.com\/set-default-payment\/.*/,
 	'sharecode': /^https:\/\/sharecode\.ft\.com/,
 	'sharecount': /https?:\/\/sharecount\.webservices\.ft\.com\//,
 	'smartology': /^https?:\/\/c\.smartology\.co\/matches\/pcid\/ft\.com\%252Fcontent\%252F/,


### PR DESCRIPTION
## Adds set-default-payment-test url to services

Currently the metrics only check the prod (api.ft.com) version of the set-default-payment url. This currently causing an error in https://ft-next-profile-eu.herokuapp.com/__health 

This PR adds the **test** (api-t.ft.com) to the list of services.

