### PR TITLE
add cloudfront.net services to next-metrics

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -66,6 +66,7 @@ module.exports = {
 	'circleci-v1-project-api': /https:\/\/circleci\.com\/api\/v1\.?[0-9]?\/project\/[\w\-\/]+/,
 	'classification-api': /https:\/\/content-classification-api\.ft\.com\//,
 	'cloudinary': /^https?:\/\/res\.cloudinary\.com/,
+	'cloudfront': /^https?:\/\/[\w\-]+\.cloudfront\.net/,
 	'consent-api': /^https:\/\/(beta-)?api\.ft\.com\/consent/,
 	'consent-api-glb': /^https:\/\/consent-api-glb-prod\.memb\.ft\.com/,
 	'consent-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/consent/,


### PR DESCRIPTION
Why ?
Last week we have changed next-es-interface instrumenting almost all fetch that this app does. So on Friday there were an alerts notifying that a service wasn't registered in next-metrics from this app.
```
"checkOutput": "https://d1e00ek4ebabms.cloudfront.net/production/uploaded-files/ft-news-briefing-2e004171-2412-45a7-969b-31ddb3890ac8.png services called but no metrics set up."
```
