### PR TITLE
ACC-1799 improve newsletters regex

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -182,7 +182,7 @@ module.exports = {
 	'membership-idm-login': /^https:\/\/api\.ft\.com\/idm\/v1\/login/,
 	'membership-idm-test': /^https:\/\/api-t\.ft\.com\/idm\/v1\/users\//,
 	'membership-invoice': /^https:\/\/invoice-svc-[^\.]+.memb\.ft\.com\/membership\/invoices/,
-	'membership-newsletter-service': /^https:\/\/api.ft.com\/newsletters\//,
+	'membership-newsletter-service': /^https:\/\/api.ft.com\/newsletters.*/,
 	'membership-subscriptions': /^https:\/\/api\.ft\.com\/membership\/subscriptions\/.*/,
 	'membership-subs-history': /^https:\/\/api\.ft\.com\/membership\/subs-history\/.*/,
 	'membership-subs-history-test': /^https:\/\/api-t\.ft\.com\/membership\/subs-history\/.*/,


### PR DESCRIPTION
The original regex of `/^https:\/\/api.ft.com\/newsletters\//` only works if there is a `/` after `newsletters` but it looks like it's not always the case. This PR removed the last `/` which should work to catch the base url. It also adds a catch-all `.*` for all extensions of the URL. 

Ticket https://financialtimes.atlassian.net/browse/ACC-1799