### PR TITLE
Add Heroku Metrics to list of services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -141,6 +141,7 @@ module.exports = {
 	'graphite': /^https?:\/\/www\.hostedgraphite\.com\//,
 	'graphql': /^https?:\/\/api\.ft\.com\/graphql\//,
 	'heroku-api': /^https?:\/\/api\.heroku\.com/,
+	'heroku-metrics-api': /^https:\/\/api\.metrics\.heroku\.com/,
 	'hui': /^https?:\/\/api\.ft\.com\/hui\//,
 	'hui-content': /^https?:\/\/api\.ft\.com\/hui\/content/,
 	'ig-coronavirus-map': /^https?:\/\/ft-ig-content-prod.s3-eu-west-1.amazonaws.com\/v2\/Financial-Times\/data-journalism-covid19-data\/main\/world-map.json/,


### PR DESCRIPTION
next-health is calling this API to gather application metrics.