### PR TITLE
ACC-1814: add next-newsletters-page to registry

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -123,6 +123,7 @@ module.exports = {
 	'ft-next-popular-api-videos': /https:\/\/ft-next-popular-api\.herokuapp\.com\/videos/,
 	'ft-next-preflight-canary': /^https?:\/\/ft-next-preflight-canary-eu\.herokuapp\.com/,
 	'ft-next-retention': /^https?:\/\/ft-next-retention-(eu|us)\.herokuapp\.com/,
+	'ft-next-newsletters-page': /^https?:\/\/ft-next-newsletters-page-(eu|us)\.herokuapp\.com/,
 	'ft-next-service-registry': /https?:\/\/next-registry\.ft\.com/,
 	'ft-next-session-service': /^https?:\/\/session-next\.ft\.com/,
 	'ft-next-sharedcount-api': /^https?:\/\/ft-next-sharedcount-api\.herokuapp\.com/,


### PR DESCRIPTION
we're seeing an alert for [next-newsletters-page](https://heimdall.ftops.tech/system?returnTo=%2Foperations&code=next-newsletters-page#monitored-checks-list) for both EU/US seems there was a deployment that coincides with timing when the alert started. Heroku logs shows HEALTHCHECK_IS_FAILING

[slack](https://financialtimes.slack.com/archives/C3LRB6JCE/p1656631303348449?thread_ts=1656543852.581899&cid=C3LRB6JCE)