### PR TITLE
Add api-t.ft.com/graphql/v1/api to services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -1,4 +1,18 @@
-module.exports = {
+const services = {
+	'api-test-graphql-v1': {
+		domain: 'api-t.ft.com',
+		path: 'graphql/v1/api',
+	}
+};
+
+const generatedRegexes = {};
+
+Object.keys(services).map(serviceId => {
+	const service = services[serviceId];
+	generatedRegexes[serviceId] = new RegExp(`^https:\/\/${service.domain}\/${service.path}`);
+});
+
+const legacyRegexes = {
 	'acast': /^https:\/\/media\.acast\.com/,
 	'acast-thumbnails': /^https:\/\/thumborcdn\.acast\.com/,
 	'access': /^https:\/\/access\.ft\.com/,
@@ -346,4 +360,9 @@ module.exports = {
 	'white-label-consent-thebanker': /^https:\/\/(consent|cookies)\.thebanker\.com/,
 	'white-label-consent-thebankerdatabase': /^https:\/\/(consent|cookies)\.thebankerdatabase\.com/,
 	'white-label-consent-catchall': /^https:\/\/(consent|cookies)\.*/
+};
+
+module.exports = {
+	...legacyRegexes,
+	...generatedRegexes
 };


### PR DESCRIPTION
next-profile is requesting this service which is causing its healthcheck to fail intermittently.

https://heimdall.ftops.tech/system?code=next-profile

I've done this in a slightly different way because this new structured format might allow us in future to add tests to ensure that (for example) the domain has a DNS record or provide some example URLs which we can verify work properly.

It also means that developers don't have to write regexes frequently anymore.

---

There's no change to the API here so I don't think this results in a breaking change.

Are we comfortable with this approach and if so would you like me to write a test or two?