### PR TITLE
add service to fetch index editorial components in next-article

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -91,6 +91,7 @@ module.exports = {
 	'device-atlas': /^https?:\/\/deviceatlas\.com/,
 	'dfp': /^https?:\/\/securepubads\.g\.doubleclick\.net\/gampad\/ads/,
 	'dni': /^https:\/\/ft-api-dev01\.rtrsupport\.de\/api\//,
+	'editorial-components-json-public': /^https:\/\/ft-next-hashed-assets-prod(-us)?\.s3\.amazonaws\.com\/hashed-assets\/page-kit\/components\.json/,
 	'email-platform': /^https:\/\/(email-webservices\.ft\.com|ep\.ft\.com)/,
 	'email-platform-lists': /^https?:\/\/ep\.ft\.com\/user-lists\/users\/.*\/lists/,
 	'email-webservices-api': /^https:\/\/(?:[A-F0-9]*:[A-F0-9]*@)?(email-webservices\.ft\.com|ep\.ft\.com)\//,


### PR DESCRIPTION
Add service pointing to aws s3 that is fetched by next-article for editorial components feature