### PR TITLE
ACC-1932 Add graphql-gateway urls to services allowed

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -144,6 +144,8 @@ module.exports = {
 	'graphite': /^https?:\/\/www\.hostedgraphite\.com\//,
 	'graphql': /^https?:\/\/api\.ft\.com\/graphql\//,
 	'graphql-test': /^https?:\/\/api-t\.ft\.com\/graphql\//,
+	'graphql-gateway': /^https?:\/\/api\.ft\.com\/graphql\/v1\/api/,
+	'graphql-gateway-test': /^https?:\/\/api-t\.ft\.com\/graphql\/v1\/api/,
 	'heroku-api': /^https?:\/\/api\.heroku\.com/,
 	'heroku-metrics-api': /^https:\/\/api\.metrics\.heroku\.com/,
 	'hui': /^https?:\/\/api\.ft\.com\/hui\//,


### PR DESCRIPTION
Add the GraphQL gateway URLs (both test and prod) to the list of allowed services. 
This change is required to mitigate this alert:
![Screenshot 2022-09-14 at 14 13 48](https://user-images.githubusercontent.com/10453619/190163795-dba4ec58-426c-41a1-8563-8877590a15e2.png)
It's firing because we've made changes to the `n-membership-sdk` so that it calls `https://api-t.ft.com/graphql/v1/api` and `https://api.ft.com/graphql/v1/api` instead of the direct GraphQL endpoints

[Ticket](https://financialtimes.atlassian.net/jira/software/c/projects/ACC/boards/1461?modal=detail&selectedIssue=ACC-1932)

