### PR TITLE
Remove references to unused next-navigation S3 buckets

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -196,8 +196,6 @@ module.exports = {
 	'messaging-guru': /^https:\/\/ft\.com\/__message\/.*/,
 	'myft-api': /https?:\/\/myft-api\.ft\.com/,
 	'navigation-api': /next-navigation\.ft\.com/,
-	'navigation-eu-bucket': /ft-next-navigation\.s3-website-eu-west-1\.amazonaws\.com/,
-	'navigation-us-bucket': /ft-next-navigation-us\.s3-website-us-east-1\.amazonaws\.com/,
 	'newspaper-del-date-gateway': /^https:\/\/(?:beta-)?api\.ft\.com\/newspaper\/info\/first-delivery-date/,
 	'newspaper-del-date-gateway-test': /^https:\/\/(?:beta-)?api-t\.ft\.com\/newspaper\/info\/first-delivery-date/,
 	'newspaper-del-date-svc': /^https:\/\/newspaper-delivery-sched-svc-gw-eu-west-1-prod\.memb\.ft\.com\/schedules\/first-delivery/,


### PR DESCRIPTION
CPREL-341

https://financialtimes.atlassian.net/browse/CPREL-341

> We discovered this bucket while working on the incident response to `next-navigation-api`.
>
> It’s mentioned in the codebase but doesn’t appear used anywhere in production. The navigation is the same as it was in 2017.

#### Definition of done

> - [ ] Remove references to ft-next-navigation S3 bucket from anywhere you can find it