### PR TITLE
Adds newsletter feed regex

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -196,6 +196,7 @@ module.exports = {
 	'messaging-guru': /^https:\/\/ft\.com\/__message\/.*/,
 	'myft-api': /https?:\/\/myft-api\.ft\.com/,
 	'navigation-api': /next-navigation\.ft\.com/,
+	'newsletter-feed': /^https?:\/\/(www\.)?ft.com\/[\w\-]+\?.*format=json.*/,
 	'newspaper-del-date-gateway': /^https:\/\/(?:beta-)?api\.ft\.com\/newspaper\/info\/first-delivery-date/,
 	'newspaper-del-date-gateway-test': /^https:\/\/(?:beta-)?api-t\.ft\.com\/newspaper\/info\/first-delivery-date/,
 	'newspaper-del-date-svc': /^https:\/\/newspaper-delivery-sched-svc-gw-eu-west-1-prod\.memb\.ft\.com\/schedules\/first-delivery/,


### PR DESCRIPTION
The new design from `next-newsletter-signup` uses the feed from `next-stream-page` to get some data.

Example urls:
https://www.ft.com/unhedged?format=json
https://www.ft.com/inside-politics?format=json
https://www.ft.com/swamp-notes?format=json