### PR TITLE
ACQ-2101: add salesforce uat url

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -259,6 +259,7 @@ module.exports = {
 	'salesforce-auth-api': /^https:\/\/login\.salesforce\.com\/services\/oauth2\/token/,
 	'salesforce-auth-api-test': /^https:\/\/test\.salesforce\.com\/services\/oauth2\/token/,
 	'salesforce-contract-api': /^https:\/\/financialtimes\.my\.salesforce\.com\/services\/apexrest\/SCRMKATContract\/.*/,
+	'salesforce-contract-api-uat': /^https:\/\/financialtimes--uat\.sandbox\.my\.salesforce\.com\/services\/apexrest\/SCRMKATContract\/.*/,
 	'sapi': /^https?:\/\/api\.ft\.com\/content\/search\/v1/,
 	'sapi-2': /^https?:\/\/search-services\.ft\.com\/search-services\/search/,
 	'session-api': /^https:\/\/sessionapi\.memb\.ft\.com\/membership\/sessions/,


### PR DESCRIPTION
It looks like salesforce is now pointing to a uat url.
next-subscribe needs to talk to salesforce to get some licence / contract information.

The salesforce URL is returned to next-subscribe dynamically here: https://github.com/Financial-Times/next-subscribe/blob/0b277c0e05b0c671f9e03659f62609bcbf5728dd/server/middleware/get-licence-contract.js#L72-L74

This causes next-subscribe to alert.

Ticket:
https://financialtimes.atlassian.net/browse/ACQ-2101