### PR TITLE
DD-860 Add specific endpoint for user-status and user-demographics

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -177,7 +177,7 @@ module.exports = {
 	'maxmind-prod-api': /^https:\/\/(spoor-maxmind-api\.ft\.com|api\.ft\.com\/spoor-maxmind)/,
 	'membership-auth-svc': /^https?:\/\/api-authz-svc\.memb\.ft\.com\/(api\/)?v2\/authorize(-server)?/,
 	'membership-b2b-fulfil-svc': /^https?:\/\/b2b-fulfil-svc-eu-prod\.memb\.ft\.com\/.*/,
-	'membership-graphql-user-status': /^https:\/\/api\.ft\.com\/memb-query\/api\/spoor-enrichment-user-id/,
+	'membership-graphql-user-status': /^https:\/\/api\.ft\.com\/memb-query\/api\/(spoor-enrichment-user-id|spoor-enrichment-ip)/,
 	'membership-graphql-user-demographics': /^https:\/\/api\.ft\.com\/memb-query\/api\/spoor-enrichment-session/,
 	'membership-graphql': /^https:\/\/api\.ft\.com\/memb-query\/api/,
 	'membership-graphql-gtg': /^https:\/\/memb-graphql-api-(eu|us)-prod\.memb\.ft\.com\/.*/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -177,6 +177,8 @@ module.exports = {
 	'maxmind-prod-api': /^https:\/\/(spoor-maxmind-api\.ft\.com|api\.ft\.com\/spoor-maxmind)/,
 	'membership-auth-svc': /^https?:\/\/api-authz-svc\.memb\.ft\.com\/(api\/)?v2\/authorize(-server)?/,
 	'membership-b2b-fulfil-svc': /^https?:\/\/b2b-fulfil-svc-eu-prod\.memb\.ft\.com\/.*/,
+	'membership-graphql-user-status': /^https:\/\/api\.ft\.com\/memb-query\/api\/spoor-enrichment-user-id/,
+	'membership-graphql-user-demographics': /^https:\/\/api\.ft\.com\/memb-query\/api\/spoor-enrichment-session/,
 	'membership-graphql': /^https:\/\/api\.ft\.com\/memb-query\/api/,
 	'membership-graphql-gtg': /^https:\/\/memb-graphql-api-(eu|us)-prod\.memb\.ft\.com\/.*/,
 	'membership-graphql-test': /^https:\/\/api-t\.ft\.com\/memb-query\/api/,


### PR DESCRIPTION
Context:

The `user-status` endpoint called from [spoor-enrichment](https://github.com/Financial-Times/spoor-enrichment/blob/master/server/transforms/user-status-api.js#L31-L37) was using the generic membership-graphql endpoint for tracking the number of requests. This will be causing some wrong metrics after including the [user-demographic](https://github.com/Financial-Times/spoor-enrichment/blob/DD-860/server/sinks/amplitude/transformers/user-demographic.js#L35) endpoint since they share the same generic membership-graphql endpoint. The changes on this pull request are for isolating these two endpoints for avoiding wrong metrics.