### PR TITLE
Drop Node.js 14 support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,14 +150,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
 
   build-test-publish:
     when:
@@ -172,7 +172,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           filters:
             <<: *filters_version_tag
@@ -181,7 +181,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - publish:
           context: npm-publish-token
           filters:
@@ -206,14 +206,14 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
 
   nightly:
     when:
@@ -230,7 +230,7 @@ workflows:
           name: build-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
       - test:
           requires:
             - build-v<< matrix.node-version >>
@@ -238,7 +238,7 @@ workflows:
           name: test-v<< matrix.node-version >>
           matrix:
             parameters:
-              node-version: [ "16.14", "14.19" ]
+              node-version: [ "16.14" ]
 
 notify:
   webhooks:

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "supertest": "^3.1.0"
       },
       "engines": {
-        "node": "14.x || 16.x",
+        "node": "16.x",
         "npm": "7.x || 8.x"
       }
     },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "supertest": "^3.1.0"
   },
   "engines": {
-    "node": "14.x || 16.x",
+    "node": "16.x",
     "npm": "7.x || 8.x"
   },
   "scripts": {


### PR DESCRIPTION
No dependency bumps because we're not releasing a new major of n-logger.