### PR TITLE
Add snr-engagement-metrics-api service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -98,6 +98,7 @@ module.exports = {
 	'email-webservices-api': /^https:\/\/(?:[A-F0-9]*:[A-F0-9]*@)?(email-webservices\.ft\.com|ep\.ft\.com)\//,
 	'encryption-api': /next-encryption-api\.ft\.com/,
 	'exec-appointments': /^https?:\/\/www\.exec-appointments\.com\/widget\/jobs\/;i=11/,
+	'snr-engagement-metrics-api': /^https:\/\/api\.ft\.com\/snr\/v1\/engagement-metrics/,
 	'fastly': /^https?:\/\/next\.ft\.com/,
 	'fastly-api': /^https?:\/\/api\.fastly\.com/,
 	'fastly-rt': /^https?:\/\/rt\.fastly\.com/,


### PR DESCRIPTION
Using the system code as the metric name: https://biz-ops.in.ft.com/System/snr-engagement-metrics-api


Also it's wierd that we're not getting the standard alert firing as this is missing in production.