### PR TITLE
Add metrics URLs for Zephr

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -341,6 +341,8 @@ module.exports = {
 	'www-article': /https:\/\/www\.ft\.com\/content\/.+/,
 	'www-well-known': /https:\/\/www\.ft\.com\/.well-known\/.+/,
 	'www-verify-backend-key': /https:\/\/www\.ft\.com\/__verify-ft-next-backend-keys/,
+	'zephr-production': /https:\/\/financial-times-financial-times\.cdn\.zephr\.com\//,
+	'zephr-staging': /https:\/\/financial-times-financial-times\.preview\.zephr\.com\//,
 	'zuora-system-status': /trust\.zuora\.com/, // used in next-signup healthchecks
 	// white-label consent & cookie metrics for Specialist Titles
 	// we need them here to silence the "We don't have any visibility with unregistered services" healthchecks


### PR DESCRIPTION
Alerting in preflight. Usage is here: https://github.com/Financial-Times/next-preflight/blob/main/server/tasks/zephr-access-decision.js