### PR TITLE
Add the subs transitions endpoint as a service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -310,6 +310,8 @@ module.exports = {
 	'subscription-api-test-subscribe-direct': /^https:\/\/(beta-)?api-t\.ft\.com\/membership\/subscriptions\/v1\/actions\/subscribe/,
 	'subscriptions-api': /^https:\/\/(beta-)?api\.ft\.com\/transitions\/subscriptions\//,
 	'subscriptions-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/transitions\/subscriptions\//,
+	'subscriptions-api-transitions': /^https:\/\/(beta-)?api\.ft\.com\/subs\/transitions\//,
+	'subscriptions-api-transitions-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/transitions\//,
 	'tag-facets-api': /^https?:\/\/tag-facets-api\.ft\.com/,
 	'temporize': /^https:\/\/api\.temporize\.net\//,
 	'tls-check-memb': /^https:\/\/howsmyssl\.memb\.ft\.com\/a\/check/,


### PR DESCRIPTION
The subs transition endpoint is now used in next-profile as part of a journey that allows users to change their payment term from Monthly to Annual

https://github.com/Financial-Times/next-profile/pull/1437/files#diff-83c67bc738ae4ae0e9bb9d98d44a80fe8e783947ec9c0b9a35d564aa01e17d95R66