### PR TITLE
Add metrics URLs for live events api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -170,6 +170,8 @@ module.exports = {
 	'lantern': /^https?:\/\/api-lantern\.ft\.com\/.*/,
 	'licence-seat-holders': /^https?:\/\/api\.ft\.com\/licence-seat-holders\/.*/,
 	'lighthouse': /^https:\/\/api\.ft\.com\/lighthouse\/.*/,
+	'live-events-api':/^https:\/\/api\.ft\.com\/live-events\/.*/,
+	'live-events-api-test':/^https:\/\/api-t\.ft\.com\/live-events\/.*/,
 	'livefyre': /https?\:\/\/ft\.bootstrap\.fyre\.co/,
 	'login-api-ft': /^https:\/\/(beta-)?api\.ft\.com\/login/,
 	'login-api-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/login/,


### PR DESCRIPTION
Jira ticket: [HIVE-1465](https://financialtimes.atlassian.net/browse/HIVE-1465)
### What
Added regex for live events api url

[HIVE-1465]: https://financialtimes.atlassian.net/browse/HIVE-1465?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ