### PR TITLE
adds urls for subs-graphql

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -314,6 +314,8 @@ module.exports = {
 	'subscriptions-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/transitions\/subscriptions\//,
 	'subscriptions-api-transitions': /^https:\/\/(beta-)?api\.ft\.com\/subs\/transitions\//,
 	'subscriptions-api-transitions-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/transitions\//,
+	'subs-graphql': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query\/api\//,
+	'subs-graphql-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/query\/api\//,
 	'tag-facets-api': /^https?:\/\/tag-facets-api\.ft\.com/,
 	'temporize': /^https:\/\/api\.temporize\.net\//,
 	'tls-check-memb': /^https:\/\/howsmyssl\.memb\.ft\.com\/a\/check/,


### PR DESCRIPTION
Adds the subs-graphql endpoints (test and prod) to the services
Usage in next-retention