### PR TITLE
chore: Add unmonitored urls for next-retention to  metrics

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -339,7 +339,6 @@ module.exports = {
 	'user-svc': /^https:\/\/(beta-)?api\.ft\.com\/users/,
 	'user-svc-test': /^https:\/\/(beta-)?api-t\.ft\.com\/users/,
 	'introductory-offers-for-apple': /^https:\/\/api.appstoreconnect\.apple\.com\/v1\/subscriptions\/[0-9]+\/introductoryOffers/,
-	'volt-db-api': /^https:\/\/voltdb-api-global\.in\.ft\.com/,
 	'utopia-test': /^https:\/\/apitest\.utopiaanalytics\.com/,
 	'utopia-prod': /^https:\/\/api\.utopiaanalytics\.com/,
 	'video': /https?:\/\/next-video\.ft\.com/,

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -338,6 +338,8 @@ module.exports = {
 	'user-subs-status-svc': /^https:\/\/(?:beta-)?api\.ft\.com\/users\/[0-9a-f]{8}-(?:[0-9a-f]{4}-){3}[0-9a-f]{12}\/subs-status/,
 	'user-svc': /^https:\/\/(beta-)?api\.ft\.com\/users/,
 	'user-svc-test': /^https:\/\/(beta-)?api-t\.ft\.com\/users/,
+	'introductory-offers-for-apple': /^https:\/\/api.appstoreconnect\.apple\.com\/v1\/subscriptions\/[0-9]+\/introductoryOffers/,
+	'volt-db-api': /^https:\/\/voltdb-api-global\.in\.ft\.com/,
 	'utopia-test': /^https:\/\/apitest\.utopiaanalytics\.com/,
 	'utopia-prod': /^https:\/\/api\.utopiaanalytics\.com/,
 	'video': /https?:\/\/next-video\.ft\.com/,


### PR DESCRIPTION
Apparently next-retention is throwing an alert for ops team because of unmonitored metrics that we have not added.
This PR adds the metrics that are missing for use to properly monitor all the end points that we are calling in next-retention.

[heimdall](https://heimdall.ftops.tech/system?code=next-retention#monitored-checks-list)

[Jjira ticket](https://financialtimes.atlassian.net/browse/ACC-2558)