### PR TITLE
Remove trailing slash from ip-voltdb-api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -161,7 +161,7 @@ module.exports = {
 	'insights-api-recommended-articles': /^https:\/\/api\.ft\.com\/snr\/v1\/insights\/recommended-articles\/[\w\-]+/,
 	'insights-api-similarity-articles': /^https:\/\/api\.ft\.com\/snr\/v1\/insights\/recommendations\/articles\/methods\/similarity/,
 	'insights-api-topic-recommendations': /^https:\/\/api\.ft\.com\/snr\/v1\/insights\/topic-recommendations\/[\w\-]+/,
-	'ip-voltdb-api': /^https?:\/\/voltdb-api-(us|eu|eu-test|global).in.ft.com\//,
+	'ip-voltdb-api': /^https?:\/\/voltdb-api-(us|eu|eu-test|global).in.ft.com/,
 	'three-play-media': /^https:\/\/api\.3playmedia\.com\/v3\/.*/,
 	'kat': /^https?:\/\/kat\.ft\.com\/api\//,
 	'keen': /^https?:\/\/api\.keen\.io/,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7842,9 +7842,9 @@
       }
     },
     "node_modules/underscore": {
-      "version": "1.5.2",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.5.2.tgz",
-      "integrity": "sha1-EzXF5PXm0zu7SwBrqMhqAPVW3gg=",
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g==",
       "dev": true
     },
     "node_modules/unique-filename": {


### PR DESCRIPTION
This isn't really needed and some services are calling it without the slash.