### PR TITLE
Fixing regex for offers-by-country-code-api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -233,7 +233,7 @@ module.exports = {
 	'n-ui-assets': /ft-next-n-ui-prod(-us)?\.s3-website-(eu-west|us-east)-1\.amazonaws\.com\/__assets\/n-ui/,
 	'offer-api': /^https:\/\/(beta-)?api\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
 	'offer-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/offers\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}/,
-	'offers-by-country-code-api': /^https:\/\/api\.ft\.com\/subs\/query\/api\/offers-by-country-code\/.*/,
+	'offers-by-country-code-api': /^https:\/\/api\.ft\.com\/subs\/query\/api\/offers-by-country-code/,
 	'old-live-blog-images': /^https?:\/\/e9b042pk7f\.execute-api\.eu-west-1\.amazonaws\.com\/prod\/images/,
 	'old-live-blog-posts': /^https?:\/\/e9b042pk7f\.execute-api\.eu-west-1\.amazonaws\.com\/prod\/posts-[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}\.json/,
 	'ombudsman': /^https?:\/\/ombudsman\.in\.ft\.com/,


### PR DESCRIPTION
Earlier regex - `/^https:\/\/api\.ft\.com\/subs\/query\/api\/offers-by-country-code\/.*/`
This was not right as the URL is - `https://api.ft.com/subs/query/api/offers-by-country-code `
New regex - `/^https:\/\/api\.ft\.com\/subs\/query\/api\/offers-by-country-code/`