### PR TITLE
[CON-2875] Add `singlestore-api` service to the registry

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -287,6 +287,7 @@ module.exports = {
 	'set-default-payment-test': /^https:\/\/api-t\.ft\.com\/set-default-payment\/.*/,
 	'sharecode': /^https:\/\/sharecode\.ft\.com/,
 	'sharecount': /https?:\/\/sharecount\.webservices\.ft\.com\//,
+	'singlestore-api': /^https:\/\/singlestore-api-(global|eu|us|test|eu-test|us-test)\.in\.ft\.com/,
 	'smartology': /^https?:\/\/c\.smartology\.co\/matches\/pcid\/ft\.com\%252Fcontent\%252F/,
 	'spark-lists': /^https?:\/\/spark-lists\.ft\.com/,
 	'spark-lists-api-v1': /^https:\/\/api\.ft\.com\/spark-lists\/v1/,


### PR DESCRIPTION
## What's changed

Content discovery team needs to migrate `next-myft-api` from `VoltDB` domains to `SingleStoreDB` ones.
 
[Migration guide](https://docs.google.com/document/d/12TC2gyqdz0gb8MOQqXSrW0G7ttfo3jEnakwR9BOeTtU/edit) 
[JiraTask](https://financialtimes.atlassian.net/jira/software/c/projects/CON/boards/1061?assignee=712020%3Adda768db-49f7-48a4-8522-9de57cd1bdfb&selectedIssue=CON-2875)

Migration PR > https://github.com/Financial-Times/next-myft-api/pull/952

List of new domains:

- https://singlestore-api-global.in.ft.com/
- https://singlestore-api-eu.in.ft.com/
- https://singlestore-api-us.in.ft.com/
- https://singlestore-api-test.in.ft.com/
- https://singlestore-api-eu-test.in.ft.com/
- https://singlestore-api-us-test.in.ft.com/
