### PR TITLE
Adding redeemable-email-tokens apis

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -265,6 +265,8 @@ module.exports = {
 	'qualtrics': /^https:\/\/.*\.qualtrics\.com\/API\/v3\/.*/,
 	'redeemable-token-svc-ft': /^https:\/\/(beta-)?api\.ft\.com\/redeemable-tokens\/.*/,
 	'redeemable-token-svc-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/redeemable-tokens\/.*/,
+	'redeemable-email-tokens-ft': /^https:\/\/api\.ft\.com\/redeemable-email-tokens\/.*/,
+	'redeemable-email-tokens-ft-test': /^https:\/\/api-t\.ft\.com\/redeemable-email-tokens\/.*/,
 	'rj-capi-mock': /^https:\/\/s3-eu-west-1\.amazonaws\.com\/rj-xcapi-mock\/production\/[0-9a-f]{8}-([0-9a-f]{4}-){3}[0-9a-f]{12}(\.json)?/,
 	'rj-up': /^https?:\/\/rj-up\.ft\.com/,
 	'salesforce-auth-api': /^https:\/\/login\.salesforce\.com\/services\/oauth2\/token/,


### PR DESCRIPTION
### Change
Adding following 2 apis in the services list -
`https://api.ft.com/redeemable-email-tokens/*`
`https://api-t.ft.com/redeemable-email-tokens/*`

We have migrated redeemable token logic from `n-membership-sdk` to `next-subscribe`. This PR adds missing APIs to the APIs list.

### Alert
https://heimdall.ftops.tech/system?returnTo=%2Foperations&code=next-subscribe#monitored-checks-list

### Ticket
https://financialtimes.atlassian.net/browse/ACQ-2655
