### PR TITLE
Remove n-service-worker from services.js

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -286,7 +286,6 @@ module.exports = {
 	'secure-blogs': /^https?:\/\/secure-blogs\.ft\.com/,
 	'segment-id-api': /^https?:\/\/segment-metadata-api\.dw\.in\.ft\.com/,
 	'sentry-api': /^https?:\/\/sentry\.io\/api/,
-	'service-worker': /^https?:\/\/ft\.com\/__sw-prod\.js/,
 	'sessions-api-ft': /^https:\/\/(beta-)?api\.ft\.com\/sessions/,
 	'sessions-api-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/sessions/,
 	'set-default-payment': /^https:\/\/api\.ft\.com\/set-default-payment\/.*/,


### PR DESCRIPTION
This PR is a part of [decommission myFT desktop push notifications and n-service-worker](https://financialtimes.atlassian.net/browse/CON-3128)