### PR TITLE
Add Spark Pages API

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -276,6 +276,7 @@ module.exports = {
 	'smartology': /^https?:\/\/c\.smartology\.co\/matches\/pcid\/ft\.com\%252Fcontent\%252F/,
 	'spark-lists': /^https?:\/\/spark-lists\.ft\.com/,
 	'spark-lists-api-v1': /^https:\/\/api\.ft\.com\/spark-lists\/v1/,
+	'spark-pages-api-v1': /^https:\/\/api\.ft\.com\/spark-pages\/v1/,
 	'speedcurve-api': /^https:\/\/api\.speedcurve\.com/,
 	'splunk-hec': /^https:\/\/http-inputs-financialtimes\.splunkcloud\.com\/services\/collector\/event/,
 	'spoor-device-atlas-api': /^https?:\/\/(spoor-deviceatlas-api\.ft\.com|api\.ft\.com\/spoor-device-atlas)/,


### PR DESCRIPTION
Required for migration from Spark Lists API to Spark Pages API  see https://github.com/Financial-Times/dotcom-pages/pull/558.