### PR TITLE
CON-3366 - add /core/search service

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -266,6 +266,8 @@ module.exports = {
 	'slack': /^https:\/\/hooks\.slack\.com\//,
 	's3-redshift': /^https:\/\/ft-next-redshift\.s3\.amazonaws\.com/,
 	'search-api': /https?:\/\/www\.ft\.com\/search-api/,
+	'search-core': /^https:\/\/api\.ft\.com\/core\/search/,
+	'search-core-test': /^https:\/\/api-t\.ft\.com\/core\/search/,
 	'segment-id-api': /^https?:\/\/segment-metadata-api\.dw\.in\.ft\.com/,
 	'sentry-api': /^https?:\/\/sentry\.io\/api/,
 	'sessions-api-ft': /^https:\/\/(beta-)?api\.ft\.com\/sessions/,


### PR DESCRIPTION
### Description

Adding metrics service for 

- Prod: `api.ft.com/core/search`
- Staging: `api-t.ft.com/core/search`