### PR TITLE
add pro-central-banking to the list of services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -247,6 +247,7 @@ module.exports = {
 	'portfolio': /https?\:\/\/(?:209\.234\.235\.243|portfolio\.ft\.com)/,
 	'propensity-api': /^https?:\/\/api\.ft\.com\/hui\/visitors/,
 	'propensity-api-direct': /^http:\/\/10\.170\.(?:12|13)\.(?:130|143)\/visitors/,
+	'pro-central-banking': /https\:\/\/professional-monetary-policy-radar\.ft\.com\/.*/,
 	'qualtrics': /^https:\/\/.*\.qualtrics\.com\/API\/v3\/.*/,
 	'redeemable-token-svc-ft': /^https:\/\/(beta-)?api\.ft\.com\/redeemable-tokens\/.*/,
 	'redeemable-token-svc-ft-test': /^https:\/\/(beta-)?api-t\.ft\.com\/redeemable-tokens\/.*/,


### PR DESCRIPTION
We are adding an API call to pro-central-banking in n-myft-navigation (https://github.com/Financial-Times/n-myft-subnavigation/pull/33), so I'd like to include the URL in the list of services to monitor the requests coming from consuming apps using n-express.

Please note that I probably don't have permissions in this repo to merge and release a new tag so I need someone from CP to do that after the PR is approved.

Thank you!