### PR TITLE
Remove next-feedback-api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -233,7 +233,6 @@ module.exports = {
 	'next-eventpromo-api': /^https?:\/\/ft-next-eventpromo-api-(eu|us)\.herokuapp\.com/,
 	'next-eventpromo-api-sync': /^https?:\/\/ft\.com\/eventpromo\/api\/sync/,
 	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,
-	'next-feedback-api': /^https:\/\/(www\.)?ft\.com\/__feedback-api\/.*/,
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
 	'next-magnet-api-event-promo': /^https:\/\/www\.ft\.com\/eventpromo\/api.*/,
 	'next-media-api-renditions': /^https?:\/\/next-media-api\.ft\.com\/renditions\/.*/,


### PR DESCRIPTION
The feedback api has been decommissioned since the removal of qualtrics as our survey provider