### PR TITLE
fix: ci-2326 add subs graphql API to services

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -310,6 +310,8 @@ module.exports = {
 	'subscriptions-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/transitions\/subscriptions\//,
 	'subscriptions-api-transitions': /^https:\/\/(beta-)?api\.ft\.com\/subs\/transitions\//,
 	'subscriptions-api-transitions-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/transitions\//,
+	'subscriptions-api-trialists': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query\/api\/current-triallist\//,
+	'subscriptions-api-trialists-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/query\/api\/current-triallist\//,
 	'subs-graphql': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query(\/graphql)?(\/)?$/,
 	'subs-graphql-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/query(\/graphql)?(\/)?$/,
 	'subs-graphql-api': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query\/api\//,


### PR DESCRIPTION
Adding the api.ft.com/subs/query trialist check API endpoint and its test equivalent