### PR TITLE
CON-3412 - remove popular-api /articles service since it has been removed

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -123,7 +123,6 @@ module.exports = {
 	'ft-next-live-chat': /https?\:\/\/live-chat\.ft\.com/,
 	'ft-next-live-chat-staging': /https?\:\/\/ip-chatterbox-client-staging\.herokuapp\.com/,
 	'ft-next-personalised-feed-api': /^https?:\/\/(personalised-feed\.ft\.com|ft-next-personalised-feed-api\.herokuapp\.com)\/v\d+\//,
-	'ft-next-popular-api-articles': /https:\/\/ft-next-popular-api\.herokuapp\.com\/articles/,
 	'ft-next-popular-api-concepts': /https:\/\/ft-next-popular-api\.herokuapp\.com\/concepts/,
 	'ft-next-popular-api-topics': /https:\/\/ft-next-popular-api\.herokuapp\.com\/topics/,
 	'ft-next-popular-api-videos': /https:\/\/ft-next-popular-api\.herokuapp\.com\/videos/,


### PR DESCRIPTION
### Description

Removing popular-api /articles service since it'll be removed [here](https://github.com/Financial-Times/next-popular-api/pull/174)


