### PR TITLE
Default service names to reduce alerting

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,26 +149,22 @@ argument specifies what type of object it is.
 
 `next-metrics` logs details of `fetch` requests your app makes, by instrumenting [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch). or the instance that you pass on the option fetchInstance in method init. If we set the option overrideGlobalFetch to false and a fetchInstance , global.fetch wont be override or assigned with our instrumented instance.
 
-So that these metrics are properly grouped and labelled in Graphite, you need to register any HTTP endpoint you call in [`services.js`](https://github.com/Financial-Times/next-metrics/blob/HEAD/lib/metrics/services.js). Any endpoint you call that _isn't_ registered will cause [a default `n-express` healthcheck](https://github.com/Financial-Times/n-express/blob/HEAD/src/lib/unregistered-services-healthCheck.js) to fail.
+We make a guess at a service name, replacing the request host name `.` with `-` so that metrics are properly grouped and labelled in Graphite. It's possible to override this with the following **but this is not recommended and may be removed in future**:
 
-If the `Metrics: All services for ${appName} registered in next-metrics` healthcheck starts failing:
+### Manual service names
 
-1. Check the healthcheck output to see which URLs aren't registered
-2. Add these URLs to `services.js` in a new Pull Request
-3. Once reviewed and merged, tag a new [**minor** release](https://semver.org/) of `next-metrics`
-4. Once the new version of next-metrics is published, bump the version used in `n-express`
-5. Update `n-express` in your app
+Add any services you want to override the label for to [`services.js`](https://github.com/Financial-Times/next-metrics/blob/HEAD/lib/metrics/services.js).
 
 The keys in the object are labels that requests are grouped under, and the values are regexes to group by, for example:
 
 ```js
 module.exports = {
   //...
-  access: /^https:\/\/access\.ft\.com/,
+  example: /^https:\/\/example\.ft\.com/,
 };
 ```
 
-This groups all URLs starting with `https://access.ft.com` as `access` in Graphite.
+This groups all URLs starting with `https://example.ft.com` as `example` in Graphite. **Once again, we recommend not worrying about the name and letting next-metrics use a sensible default of `example-ft-com`.**
 
 ## Metrics
 

--- a/lib/metrics/fetch.js
+++ b/lib/metrics/fetch.js
@@ -30,7 +30,7 @@ module.exports = class {
 		return this.metrics[service][key];
 	}
 
-	instrument ({ metricsInstance, onUninstrumented = () => {}} = {}) {
+	instrument ({ metricsInstance } = {}) {
 		if (!global.fetch && !this.deps.fetchInstance) {
 			throw new Error('next-metrics: You need to `require(\'isomorphic-fetch\');` or pass a fetchInstance as an option before instrumenting it');
 		}
@@ -51,47 +51,51 @@ module.exports = class {
 		const that = this; // not using bind as don't want to muck around with fetch's scope
 
 		let fetchInstrumented = function (url) {
-			const service = Object.keys(that.deps.services)
+			let service = Object.keys(that.deps.services)
 				.find(serviceName => that.deps.services[serviceName].test(url));
 
-			if (service) {
-				that.getMetric(service, 'counter')
-					.inc(1);
-
-				const start = Date.now();
-				let end;
-
-				const response = fetchInstance.apply(this, arguments);
-				response.then(() => {
-					end = Date.now();
-				}).catch(() => {}); // empty catch as exceptions are handled in other promise chains
-
-				// take the metrics off the microtask queue
-				setTimeout(() => {
-					response.then(res => {
-						const status = res.status ? '' + res.status : '200';
-						const statusType = `${status.charAt(0)}xx`;
-						that.getMetric(service, 'counter', `response.status_${status}`)
-							.inc(1);
-						that.getMetric(service, 'counter', `response.status_${statusType}`)
-							.inc(1);
-						that.getMetric(service, 'histogram', `response.status_${status}.response_time`)
-							.update(end - start);
-						that.getMetric(service, 'histogram', `response.status_${statusType}.response_time`)
-							.update(end - start);
-					})
-						.catch(err => {
-							const errorType = /(timeout|socket hang up)/i.test(err.message) ? 'timeout' : 'failed';
-							that.getMetric(service, 'counter', `response.status_${errorType}`)
-								.inc(1);
-						});
-				});
-
-				return response;
-			} else {
-				onUninstrumented.apply(this, arguments);
-				return fetchInstance.apply(this, arguments);
+			if (!service) {
+				try {
+					const { hostname } = new URL(url);
+					service = hostname.replaceAll('.', '-');
+				} catch (error) {
+					service = 'unknown';
+				}
 			}
+
+			that.getMetric(service, 'counter')
+				.inc(1);
+
+			const start = Date.now();
+			let end;
+
+			const response = fetchInstance.apply(this, arguments);
+			response.then(() => {
+				end = Date.now();
+			}).catch(() => {}); // empty catch as exceptions are handled in other promise chains
+
+			// take the metrics off the microtask queue
+			setTimeout(() => {
+				response.then(res => {
+					const status = res.status ? '' + res.status : '200';
+					const statusType = `${status.charAt(0)}xx`;
+					that.getMetric(service, 'counter', `response.status_${status}`)
+						.inc(1);
+					that.getMetric(service, 'counter', `response.status_${statusType}`)
+						.inc(1);
+					that.getMetric(service, 'histogram', `response.status_${status}.response_time`)
+						.update(end - start);
+					that.getMetric(service, 'histogram', `response.status_${statusType}.response_time`)
+						.update(end - start);
+				})
+					.catch(err => {
+						const errorType = /(timeout|socket hang up)/i.test(err.message) ? 'timeout' : 'failed';
+						that.getMetric(service, 'counter', `response.status_${errorType}`)
+							.inc(1);
+					});
+			});
+
+			return response;
 		};
 
 		fetchInstrumented._instrumented = true;

--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -1,3 +1,16 @@
+// YOU MIGHT NOT NEED TO EDIT THIS FILE ANY MORE
+//
+// Hi there! We've made a change to next-metrics and the work you're about to do may
+// no longer be required. We now use a sensible default name if the URL isn't found
+// in this list. We'd prefer it if you accepted the default name rather than adding
+// new regular expressions and creating release churn.
+//
+// The generated name will be the hostname of the request with `.` replaced with `-`,
+// for example:
+//
+// access.ft.com    -->   access-ft-com
+// api.twitter.com  -->  api-twitter-com
+//
 module.exports = {
 	'acast': /^https:\/\/media\.acast\.com/,
 	'acast-thumbnails': /^https:\/\/thumborcdn\.acast\.com/,


### PR DESCRIPTION
This adds in a default service name instead of marking all unrecognised services as uninstrumented. This is the first step towards allowing us to make broader metrics/n-express changes without blocking teams from doing their work.

To get a default value we replace `.` in the request URL's host name with `-`. If we can't parse out a hostname then we default to `unknown`.

**Note to reviewers:** we had to change some indentation so [ignoring whitespace changes will make this easier to review](https://github.com/Financial-Times/next-metrics/pull/583/files?w=1).

---

See-also: [CPREL-1123](https://financialtimes.atlassian.net/browse/CPREL-1123)

[CPREL-1123]: https://financialtimes.atlassian.net/browse/CPREL-1123?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ