### PR TITLE
fix: match accept anything after path

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -322,7 +322,7 @@ module.exports = {
 	'subscriptions-api-test': /^https:\/\/(beta-)?api-t\.ft\.com\/transitions\/subscriptions\//,
 	'subscriptions-api-transitions': /^https:\/\/(beta-)?api\.ft\.com\/subs\/transitions\//,
 	'subscriptions-api-transitions-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/transitions\//,
-	'subscriptions-api-trialists': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query\/api\/current-triallist\//,
+	'subscriptions-api-trialists': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query\/api\/current-triallist.*$/,
 	'subscriptions-api-trialists-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/query\/api\/current-triallist\//,
 	'subs-graphql': /^https:\/\/(beta-)?api\.ft\.com\/subs\/query(\/graphql)?(\/)?$/,
 	'subs-graphql-test': /^https:\/\/(beta-)?api-t\.ft\.com\/subs\/query(\/graphql)?(\/)?$/,


### PR DESCRIPTION
Our healthcheck is failing as the full path (https://api.ft.com/subs/query/api/current-triallist?subscriberId=<uuid>) doesn't match