### PR TITLE
CON-3429: remove reference to event promo api

### DIFF
--- a/lib/metrics/services.js
+++ b/lib/metrics/services.js
@@ -235,7 +235,6 @@ module.exports = {
 	'next-eventpromo-api-datasource': /^https?:\/\/live\.ft\.com\/__service\/eventpromo\/.*/,
 	'next-feedback-api': /^https:\/\/(www\.)?ft\.com\/__feedback-api\/.*/,
 	'next-magnet-api': /^https?:\/\/ft-next-magnet-api-(eu|us)\.herokuapp\.com/,
-	'next-magnet-api-event-promo': /^https:\/\/www\.ft\.com\/eventpromo\/api.*/,
 	'next-media-api-renditions': /^https?:\/\/next-media-api\.ft\.com\/renditions\/.*/,
 	'next-media-api-v1': /^https?:\/\/next-media-api\.ft\.com\/v1\/.*/,
 	'next-session-lambda': /https?:\/\/[^\.]+.execute-api\.eu-west-1\.amazonaws\.com/,


### PR DESCRIPTION
Description
As part of decommission `next-eventpromo-api` we need to remove references on next-metrics
Ticket
https://financialtimes.atlassian.net/browse/CON-3429